### PR TITLE
Destagger updates horizontal coords

### DIFF
--- a/src/meteodatalab/metadata.py
+++ b/src/meteodatalab/metadata.py
@@ -193,3 +193,26 @@ def extract_pv(message: bytes) -> dict[str, xr.DataArray]:
         "ak": xr.DataArray(pv[:i], dims="z"),
         "bk": xr.DataArray(pv[i:], dims="z"),
     }
+
+
+def extract_hcoords(message: bytes) -> dict[str, xr.DataArray]:
+    """Extract horizontal coordinates.
+
+    Parameters
+    ----------
+    message : bytes
+        GRIB message containing the grid definition.
+
+    Returns
+    -------
+    dict[str, xarray.DataArray]
+        Horizontal coordinates in geolatlon.
+
+    """
+    stream = io.BytesIO(message)
+    [grib_field] = ekd.from_source("stream", stream)
+
+    return {
+        dim: xr.DataArray(dims=("y", "x"), data=values)
+        for dim, values in grib_field.to_latlon().items()
+    }

--- a/src/meteodatalab/operators/destagger.py
+++ b/src/meteodatalab/operators/destagger.py
@@ -139,17 +139,19 @@ def destagger(
     if dim == "x" or dim == "y":
         if field.attrs[f"origin_{dim}"] != 0.5:
             raise ValueError
+        attrs = _update_grid(field, dim)
         return (
             xr.apply_ufunc(
                 interpolate_midpoint,
-                field.reset_coords(drop=True),
+                field,
                 input_core_dims=[[dim]],
                 output_core_dims=[[dim]],
                 kwargs={"extend": "left"},
                 keep_attrs=True,
             )
             .transpose(*dims)
-            .assign_attrs({f"origin_{dim}": 0.0}, **_update_grid(field, dim))
+            .assign_attrs({f"origin_{dim}": 0.0}, **attrs)
+            .assign_coords(metadata.extract_hcoords(attrs["message"]))
         )
     elif dim == "z":
         if field.origin_z != -0.5:


### PR DESCRIPTION
## Purpose

Previously the destagger operation in x and y dropped the coordinates due to the latitude and longitude coordinates being outdated. However, the coordinates may still be needed for downstream operations.

## Code changes:

- `destagger` operation updates the relevant coordinates
- Added `metadata.extract_hcoords` function