### PR TITLE
fix dealing with empty dict

### DIFF
--- a/src/meteodatalab/grib_decoder.py
+++ b/src/meteodatalab/grib_decoder.py
@@ -366,7 +366,7 @@ def save(
     for idx_slice in product(*idx.values()):
         loc = {dim: value for dim, value in zip(idx.keys(), idx_slice)}
         array = field.sel(loc).values
-        metadata = md.override(to_grib(loc))
+        metadata = md.override(to_grib(loc)) if to_grib(loc) else md
 
         fs = ekd.FieldList.from_numpy(array, metadata)
         fs.write(file_handle, bits_per_value=bits_per_value)

--- a/src/meteodatalab/metadata.py
+++ b/src/meteodatalab/metadata.py
@@ -57,6 +57,8 @@ def override(message: bytes, **kwargs: typing.Any) -> dict[str, typing.Any]:
         Updated message byte string along with the geography and parameter namespaces
 
     """
+    if not kwargs:
+        return {"message": message, **extract(md)}
     stream = io.BytesIO(message)
     [grib_field] = ekd.from_source("stream", stream)
 

--- a/src/meteodatalab/metadata.py
+++ b/src/meteodatalab/metadata.py
@@ -57,8 +57,6 @@ def override(message: bytes, **kwargs: typing.Any) -> dict[str, typing.Any]:
         Updated message byte string along with the geography and parameter namespaces
 
     """
-    if not kwargs:
-        return {"message": message, **extract(md)}
     stream = io.BytesIO(message)
     [grib_field] = ekd.from_source("stream", stream)
 


### PR DESCRIPTION
## Purpose
Bug fix: 
ekd can not deal with updating metadata with an empty dict. 
This would happen when saving constant 2D fields, i.e. no time nor z dimension. 

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://meteoswiss.atlassian.net/wiki/spaces/UA/pages/20157433/Factory).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README)
- [ ] Unit tests are added or updated for non-operator code
- [ ] New operators are properly tested

Additionally, if the PR updates the version of the package

- [ ] The new version is properly set
- [ ] A Tag will be created after the bump

## Review
For the review process follow the guidelines at [Checklist](https://meteoswiss.atlassian.net/wiki/spaces/UA/pages/20156488/Code+Review)
