### PR TITLE
Pydantic v1 validator

### DIFF
--- a/src/meteodatalab/mars.py
+++ b/src/meteodatalab/mars.py
@@ -69,7 +69,7 @@ class TimeseriesFeature:
     start: int = 0
     end: int = 0
 
-    @pydantic.field_validator("type")
+    @pydantic.validator("type")
     @classmethod
     def validate_type(cls, v: str) -> str:
         if v != FeatureType.TIMESERIES:

--- a/src/meteodatalab/metadata.py
+++ b/src/meteodatalab/metadata.py
@@ -193,3 +193,26 @@ def extract_pv(message: bytes) -> dict[str, xr.DataArray]:
         "ak": xr.DataArray(pv[:i], dims="z"),
         "bk": xr.DataArray(pv[i:], dims="z"),
     }
+
+
+def extract_hcoords(message: bytes) -> dict[str, xr.DataArray]:
+    """Extract horizontal coordinates.
+
+    Parameters
+    ----------
+    message : bytes
+        GRIB message containing the grid definition.
+
+    Returns
+    -------
+    dict[str, xarray.DataArray]
+        Horizontal coordinates in geolatlon.
+
+    """
+    stream = io.BytesIO(message)
+    [grib_field] = ekd.from_source("stream", stream)
+
+    return {
+        dim: xr.DataArray(dims=("y", "x"), data=values)
+        for dim, values in grib_field.to_latlon().items()
+    }

--- a/src/meteodatalab/operators/destagger.py
+++ b/src/meteodatalab/operators/destagger.py
@@ -139,17 +139,19 @@ def destagger(
     if dim == "x" or dim == "y":
         if field.attrs[f"origin_{dim}"] != 0.5:
             raise ValueError
+        attrs = _update_grid(field, dim)
         return (
             xr.apply_ufunc(
                 interpolate_midpoint,
-                field.reset_coords(drop=True),
+                field,
                 input_core_dims=[[dim]],
                 output_core_dims=[[dim]],
                 kwargs={"extend": "left"},
                 keep_attrs=True,
             )
             .transpose(*dims)
-            .assign_attrs({f"origin_{dim}": 0.0}, **_update_grid(field, dim))
+            .assign_attrs({f"origin_{dim}": 0.0}, **attrs)
+            .assign_coords(metadata.extract_hcoords(attrs["message"]))
         )
     elif dim == "z":
         if field.origin_z != -0.5:


### PR DESCRIPTION
- field_validator is not present in pydantic v1, compatibility is needed due to mch-python-commons pinning pydantic to v1