### PR TITLE
Update metadata in vertical interpolation operators

### DIFF
--- a/poetry.toml
+++ b/poetry.toml
@@ -1,2 +1,3 @@
 [virtualenvs]
+create = true
 in-project = true

--- a/src/meteodatalab/operators/support_operators.py
+++ b/src/meteodatalab/operators/support_operators.py
@@ -8,6 +8,7 @@ from typing import Any, Literal, Optional, Sequence
 import numpy as np
 import xarray as xr
 
+# Local
 from .. import metadata
 
 

--- a/src/meteodatalab/operators/support_operators.py
+++ b/src/meteodatalab/operators/support_operators.py
@@ -8,6 +8,8 @@ from typing import Any, Literal, Optional, Sequence
 import numpy as np
 import xarray as xr
 
+from .. import metadata
+
 
 @dc.dataclass
 class TargetCoordinatesAttrs:
@@ -68,26 +70,16 @@ def init_field_with_vcoord(
     #  one should separate these from coordinate properties
     #       in the interface
     # attrs
-    attrs = parent.attrs.copy()
-    attrs["vcoord_type"] = vcoord.type_of_level
-
+    attrs = parent.attrs | metadata.override(
+        parent.message, typeOfLevel=vcoord.type_of_level
+    )
     # dims
-    def replace_vertical(items):
-        for dim, size in items:
-            if dim == "z":
-                yield vcoord.type_of_level, vcoord.size
-            else:
-                yield dim, size
-
-    # ... make sure to maintain the ordering of the dims
-    sizes = {dim: size for dim, size in replace_vertical(parent.sizes.items())}
+    sizes = dict(parent.sizes.items()) | {"z": vcoord.size}
     # coords
     # ... inherit all except for the vertical coordinates
     coords = {c: v for c, v in parent.coords.items() if c != "z"}
     # ... initialize the vertical target coordinates
-    coords[vcoord.type_of_level] = xr.IndexVariable(
-        vcoord.type_of_level, vcoord.values, attrs=dc.asdict(vcoord.attrs)
-    )
+    coords["z"] = xr.IndexVariable("z", vcoord.values, attrs=dc.asdict(vcoord.attrs))
     # dtype
     if dtype is None:
         dtype = parent.data.dtype

--- a/src/meteodatalab/operators/vertical_interpolation.py
+++ b/src/meteodatalab/operators/vertical_interpolation.py
@@ -334,8 +334,8 @@ def interpolate_k2any(
     tc_field : xarray.DataArray
         target field
         (only typeOfLevel="generalVerticalLayer" is supported)
-    tc_values : list of float
-        target coordinate values
+    tc : TargetCoordinates
+        target coordinate definition
     h_field : xarray.DataArray
         height on k levels (only typeOfLevel="generalVerticalLayer" is supported)
 

--- a/src/meteodatalab/operators/vertical_interpolation.py
+++ b/src/meteodatalab/operators/vertical_interpolation.py
@@ -81,7 +81,7 @@ def interpolate_k2p(
             f"(must be in interval [{p_tc_min}, {p_tc_max}]Pa)"
         )
     tc = TargetCoordinates(
-        type_of_level="pressure",
+        type_of_level="isobaricInPa",
         values=tc_values.tolist(),
         attrs=TargetCoordinatesAttrs(
             units="Pa",
@@ -151,7 +151,7 @@ def interpolate_k2p(
             ratio = xr.where(np.abs(p0 - p1) >= np.abs(p0 - p2), 1.0, 0.0)
 
         # ... interpolate and update field_on_tc
-        field_on_tc[{"pressure": tc_idx}] = (1.0 - ratio) * f1 + ratio * f2
+        field_on_tc[{"z": tc_idx}] = (1.0 - ratio) * f1 + ratio * f2
 
     return field_on_tc
 
@@ -306,7 +306,7 @@ def interpolate_k2theta(
         ratio = xr.where(np.abs(th2 - th1) > 0, (th0 - th1) / (th2 - th1), 0.0)
 
         # ... interpolate and update field_on_tc
-        field_on_tc[{"theta": tc_idx}] = xr.where(
+        field_on_tc[{"z": tc_idx}] = xr.where(
             folding_coord_exception, np.nan, (1.0 - ratio) * f1 + ratio * f2
         )
 
@@ -317,7 +317,7 @@ def interpolate_k2any(
     field: xr.DataArray,
     mode: Literal["low_fold", "high_fold"],
     tc_field: xr.DataArray,
-    tc_values: Sequence[float],
+    tc: TargetCoordinates,
     h_field: xr.DataArray,
 ) -> xr.DataArray:
     """Interpolate a field from model levels to coordinates w.r.t. an arbitrary field.
@@ -358,17 +358,6 @@ def interpolate_k2any(
     h_min = -1000.0
     h_max = 100000.0
 
-    tc = TargetCoordinates(
-        type_of_level=tc_field.parameter["shortName"],
-        values=list(tc_values),
-        attrs=TargetCoordinatesAttrs(
-            standard_name="",
-            long_name=tc_field.parameter["name"],
-            units=tc_field.parameter["units"],
-            positive="up",
-        ),
-    )
-
     # Prepare output field field_on_tc on target coordinates
     field_on_tc = init_field_with_vcoord(field.broadcast_like(tc_field), tc, np.nan)
 
@@ -405,6 +394,6 @@ def interpolate_k2any(
         ratio = xr.where(np.abs(t2 - t1) > 0, (value - t1) / (t2 - t1), 0.0)
 
         # ... interpolate and update field_on_tc
-        field_on_tc[{tc.type_of_level: tc_idx}] = (1.0 - ratio) * f1 + ratio * f2
+        field_on_tc[{"z": tc_idx}] = (1.0 - ratio) * f1 + ratio * f2
 
     return field_on_tc

--- a/src/meteodatalab/operators/vertical_reduction.py
+++ b/src/meteodatalab/operators/vertical_reduction.py
@@ -218,8 +218,7 @@ def integrate_k(field, operator, mode, height, h_bounds, hsurf=None):
     # typeOfFirstFixedSurface and typeOfSecondFixedSurface in GRIB2, and to set the
     # bounds attribute for the vertical
     # coordinates in NetCDF
-    h_bottom = h_bounds[0].copy()
-    h_top = h_bounds[1].copy()
+    h_bottom, h_top = (f.reset_coords("z", drop=True) for f in h_bounds)
     if mode in ["h2z", "h2h"]:
         # raise error as long as no unit test is available
         raise NotImplementedError(

--- a/src/meteodatalab/operators/vertical_reduction.py
+++ b/src/meteodatalab/operators/vertical_reduction.py
@@ -75,8 +75,7 @@ def minmax_k(field, operator, mode, height, h_bounds, hsurf=None):
     # and upper_bound_type can be used to code typeOfFirstFixedSurface
     # and typeOfSecondFixedSurface in GRIB2, and to set the bounds attribute for
     # the vertical coordinates in NetCDF
-    h_bottom = h_bounds[0].copy()
-    h_top = h_bounds[1].copy()
+    h_bottom, h_top = h_bounds
     if mode in ["h2z", "h2h"]:
         # raise error as long as no unit test is available
         raise NotImplementedError(

--- a/src/meteodatalab/operators/vertical_reduction.py
+++ b/src/meteodatalab/operators/vertical_reduction.py
@@ -218,7 +218,7 @@ def integrate_k(field, operator, mode, height, h_bounds, hsurf=None):
     # typeOfFirstFixedSurface and typeOfSecondFixedSurface in GRIB2, and to set the
     # bounds attribute for the vertical
     # coordinates in NetCDF
-    h_bottom, h_top = (f.reset_coords("z", drop=True) for f in h_bounds)
+    h_bottom, h_top = h_bounds
     if mode in ["h2z", "h2h"]:
         # raise error as long as no unit test is available
         raise NotImplementedError(

--- a/src/meteodatalab/products/ninjo_k2th.py
+++ b/src/meteodatalab/products/ninjo_k2th.py
@@ -49,7 +49,7 @@ def _compute_mean(
 ) -> xr.DataArray:
     logger.info("Computing mean potential vorticity between 700 and 900 hPa")
     isobars = interpolate_k2p(hfl, "linear_in_lnp", pressure, [700, 900], "hPa")
-    h700, h900 = isobars.transpose("pressure", ...)
+    h700, h900 = isobars.transpose("z", ...)
     return integrate_k(pot_vortic, "normed_integral", "z2z", hhl, (h900, h700))
 
 

--- a/tests/test_meteodatalab/fieldextra_templates/test_intpl_k2any.nl
+++ b/tests/test_meteodatalab/fieldextra_templates/test_intpl_k2any.nl
@@ -62,6 +62,8 @@
 
 &Process tmp1_field="HEIGHT", tag="htop", levlist=1 /
 &Process tmp1_field="HEIGHT", tag="height", voper="find_value,dbz=15.,htop,down" /
+&Process tmp1_field="HEIGHT", tag="height2", voper="find_value,dbz=10.,htop,down" /
 &Process tmp1_field="DBZ", tag="dbz" /
 
 &Process out_field = "height", tag="ECHOTOPinM", new_field_id="ECHOTOPinM", set_level_property="echo_top[dBZ],15" /
+&Process out_field = "height2", tag="ECHOTOP10inM", new_field_id="ECHOTOPinM", set_level_property="echo_top[dBZ],10" /

--- a/tests/test_meteodatalab/test_intpl_k2any.py
+++ b/tests/test_meteodatalab/test_intpl_k2any.py
@@ -14,7 +14,7 @@ from meteodatalab.operators.vertical_interpolation import (
 def test_intpl_k2theta(data_dir, fieldextra):
     # define target coordinates
     tc = TargetCoordinates(
-        type_of_level="echoTopInM",
+        type_of_level="echoTopInDBZ",
         values=[15.0],
         attrs=TargetCoordinatesAttrs(
             standard_name="",

--- a/tests/test_meteodatalab/test_intpl_k2any.py
+++ b/tests/test_meteodatalab/test_intpl_k2any.py
@@ -11,7 +11,7 @@ from meteodatalab.operators.vertical_interpolation import (
 )
 
 
-def test_intpl_k2theta(data_dir, fieldextra):
+def test_intpl_k2any(data_dir, fieldextra):
     # define target coordinates
     tc = TargetCoordinates(
         type_of_level="echoTopInDBZ",

--- a/tests/test_meteodatalab/test_intpl_k2any.py
+++ b/tests/test_meteodatalab/test_intpl_k2any.py
@@ -4,12 +4,25 @@ from numpy.testing import assert_allclose
 # First-party
 from meteodatalab.grib_decoder import GribReader
 from meteodatalab.operators.destagger import destagger
-from meteodatalab.operators.vertical_interpolation import interpolate_k2any
+from meteodatalab.operators.vertical_interpolation import (
+    interpolate_k2any,
+    TargetCoordinates,
+    TargetCoordinatesAttrs,
+)
 
 
 def test_intpl_k2theta(data_dir, fieldextra):
     # define target coordinates
-    tc_values = [15.0]
+    tc = TargetCoordinates(
+        type_of_level="echoTopInM",
+        values=[15.0],
+        attrs=TargetCoordinatesAttrs(
+            standard_name="",
+            long_name="radar reflectivity",
+            units="dBZ",
+            positive="up",
+        ),
+    )
 
     # input data
     datafile = data_dir / "COSMO-1E/1h/ml_sl/000/lfff00000000"
@@ -22,7 +35,7 @@ def test_intpl_k2theta(data_dir, fieldextra):
     hfl = destagger(ds["HHL"].squeeze(drop=True), "z")
 
     # call interpolation operator
-    echo_top = interpolate_k2any(hfl, "high_fold", ds["DBZ"], tc_values, hfl)
+    echo_top = interpolate_k2any(hfl, "high_fold", ds["DBZ"], tc, hfl)
 
     fx_ds = fieldextra("intpl_k2any")
 

--- a/tests/test_meteodatalab/test_intpl_k2any.py
+++ b/tests/test_meteodatalab/test_intpl_k2any.py
@@ -1,7 +1,6 @@
 # Third-party
-from numpy.testing import assert_allclose
-
 import pytest
+from numpy.testing import assert_allclose
 
 # First-party
 from meteodatalab.grib_decoder import GribReader

--- a/tests/test_meteodatalab/test_intpl_k2any.py
+++ b/tests/test_meteodatalab/test_intpl_k2any.py
@@ -5,9 +5,9 @@ from numpy.testing import assert_allclose
 from meteodatalab.grib_decoder import GribReader
 from meteodatalab.operators.destagger import destagger
 from meteodatalab.operators.vertical_interpolation import (
-    interpolate_k2any,
     TargetCoordinates,
     TargetCoordinatesAttrs,
+    interpolate_k2any,
 )
 
 

--- a/tools/setup_poetry.sh
+++ b/tools/setup_poetry.sh
@@ -19,6 +19,7 @@ if [ -d ${HOME}/.local/bin ]; then
     ln -sf ${poetry} ${HOME}/.local/bin/poetry
 fi
 
+${prefix}/bin/poetry config --list
 ${prefix}/bin/poetry install -vv --sync
 
 venv=$(${prefix}/bin/poetry run python -c "import sys; print(sys.prefix)")


### PR DESCRIPTION
## Purpose

Update the vertical interpolation operators to maintain the consistency of the GRIB metadata. The vertical dimension is now consistently named `z`. This will allow compatibility with the `grib_decoder.save` method. The `vcoord_type` attribute can be used to identify array that are defined on different vertical coordinates. 

## Code changes

- **Breaking:** `interpolate_k2any` replaces the `tc_values` with `tc` which is an instance of `TargetCoordinates` to allow more control on the target coordinates for the interpolation.
- **Breaking:** all operators in `vertical_interpolation` return array for which the vertical dimension is `z`.
