### PR TITLE
Add extract_keys function

### DIFF
--- a/src/meteodatalab/metadata.py
+++ b/src/meteodatalab/metadata.py
@@ -216,3 +216,34 @@ def extract_hcoords(message: bytes) -> dict[str, xr.DataArray]:
         dim: xr.DataArray(dims=("y", "x"), data=values)
         for dim, values in grib_field.to_latlon().items()
     }
+
+
+def extract_keys(message: bytes, keys: typing.Any) -> typing.Any:
+    """Extract keys from the GRIB message.
+
+    Parameters
+    ----------
+    message : bytes
+        The GRIB message.
+    keys : Any
+        Keys for which to extract values from the message.
+
+    Raises
+    ------
+    ValueError
+        if keys is None because the resulting metadata would point
+        to an eccodes handle that no longer exists resulting in a
+        possible segmentation fault
+
+    Returns
+    -------
+    Any
+        Single value if keys is a single value, tuple of values if
+        keys is a tuple, list of values if keys is a list. The type of
+        the value depends on the default type for the given key in eccodes.
+    """
+    if keys is None:
+        raise ValueError("keys must be specified.")
+    stream = io.BytesIO(message)
+    [grib_field] = ekd.from_source("stream", stream)
+    return grib_field.metadata(keys)

--- a/tests/test_meteodatalab/test_metadata.py
+++ b/tests/test_meteodatalab/test_metadata.py
@@ -1,0 +1,35 @@
+# Third-party
+import pytest
+
+# First-party
+from meteodatalab import data_source, grib_decoder, metadata
+
+
+@pytest.mark.parametrize(
+    "keys,values",
+    [
+        ("shortName", "HHL"),
+        (["number", "step"], [0, 0]),
+        (("typeOfLevel"), ("generalVertical")),
+    ],
+)
+def test_extract_keys(data_dir, keys, values):
+    cdatafile = data_dir / "COSMO-1E/1h/const/000/lfff00000000c"
+
+    source = data_source.DataSource([str(cdatafile)])
+    ds = grib_decoder.load(source, {"param": ["HHL"]})
+
+    observed = metadata.extract_keys(ds["HHL"].message, keys)
+    expected = values
+
+    assert observed == expected
+
+
+def test_extract_keys_raises(data_dir):
+    cdatafile = data_dir / "COSMO-1E/1h/const/000/lfff00000000c"
+
+    source = data_source.DataSource([str(cdatafile)])
+    ds = grib_decoder.load(source, {"param": ["HHL"]})
+
+    with pytest.raises(ValueError):
+        metadata.extract_keys(ds["HHL"].message, None)


### PR DESCRIPTION
## Purpose

Provide a function to extract given keys from a GRIB message.

## Code changes:

- Add `metadata.extract_keys` function
