### PR TITLE
update metadata of omega_slope

### DIFF
--- a/src/meteodatalab/data/field_mappings.yml
+++ b/src/meteodatalab/data/field_mappings.yml
@@ -157,6 +157,9 @@ NSSS:
 OMEGA:
   cosmo:
     paramId: 500031
+  ifs:
+    name: w
+    paramId: 135
 HHL:
   cosmo:
     paramId: 500008

--- a/src/meteodatalab/operators/omega_slope.py
+++ b/src/meteodatalab/operators/omega_slope.py
@@ -35,8 +35,25 @@ def omega_slope(
 
     Converts ECMWF etadot (deta/dt) to etadot * dp/deta, required by FLEXPART.
 
-    Note:
-    ----
+    Parameters
+    ----------
+    ps : xarray.DataArray
+        Pressure (S) (not reduced) in Pa.
+    etadot : xarray.DataArray
+        Eta-coordinate vertical velocity (deta/dt) in s**-1.
+    ak : xarray.DataArray
+        Hybrid level A coefficient.
+    bk : xarray.DataArray
+        Hybrid level B coefficient.
+
+
+    Returns
+    -------
+    xarray.DataArray
+        Vertical velocity (pressure) in Pa s**-1.
+
+    Notes
+    -----
     Fieldextra returns the parameter as ETADOT.
 
     """
@@ -54,6 +71,10 @@ def omega_slope(
     return xr.DataArray(
         data=res,
         attrs=metadata.override(
-            etadot.message, discipline=0, parameterCategory=2, parameterNumber=8
+            # Vertical velocity (pressure)
+            etadot.message,
+            discipline=0,
+            parameterCategory=2,
+            parameterNumber=8,
         ),
     )

--- a/tests/test_meteodatalab/test_flexpart.py
+++ b/tests/test_meteodatalab/test_flexpart.py
@@ -89,6 +89,14 @@ def test_flexpart(data_dir, fieldextra):
         }
     )
 
+    assert ds_out["omega"].parameter == {
+        "centre": "ecmf",
+        "paramId": 135,
+        "shortName": "w",
+        "units": "Pa s**-1",
+        "name": "Vertical velocity",
+    }
+
     assert_allclose(fs_ds_o["ETADOT"], ds_out["omega"], rtol=3e-6, atol=5e-5)
     assert_allclose(fs_ds_o["U"], ds_out["u"], rtol=3e-7, atol=5e-7)
     assert_allclose(fs_ds_o["V"], ds_out["v"], rtol=3e-7, atol=5e-7)


### PR DESCRIPTION
## Purpose

Update metadata of `omega_slope` operator.

### Note

Fieldextra returns the parameter `etadot` for the `omega_slope` operator but we return w (Vertical Velocity (Pressure)). Because according to Fieldextra's description:
Convert from ECMWF etadot (i.e. deta/dt) to etadot*dp/deta

we infer that the returned parameter aligns with the COSMO definition of omega as Vertical Velocity (Pressure) (omega=dp/dt). In ECMWF, this vertical velocity is associated with the parameter w.

Additionally, Flexpart expects the GRIB code for "etadot" but converts the ID for "etadot" (ID: 77) to vertical velocity "w" (ID: 135), as shown in these code snippets: [link](https://github.com/MeteoSwiss/flexpart/blob/main/src/readwind_ecmwf.f90#L141C1-L144C10) and [link](https://github.com/MeteoSwiss/flexpart/blob/main/src/readwind_ecmwf.f90#L191-L194).
