### PR TITLE
update metadata of gis operator

### DIFF
--- a/src/meteodatalab/operators/gis.py
+++ b/src/meteodatalab/operators/gis.py
@@ -221,7 +221,7 @@ def vref_rot2geolatlon(
     u_g, v_g = _vref_rot2geolatlon(u, v, lon, lat, grid)
 
     # bit 5 left unset since u/v relative to grid in x (i) and y (j) directions,
-    # not defined grid; bit 3 and 5 set as i, j direction increments given
+    # not defined grid; bits 3 and 4 set as i, j direction increments given
     resolution_components_flags = set_code_flag([3, 4])
 
     return (

--- a/src/meteodatalab/operators/gis.py
+++ b/src/meteodatalab/operators/gis.py
@@ -10,6 +10,8 @@ import numpy as np
 import xarray as xr
 
 # Local
+from .. import metadata
+from ..grib_decoder import set_code_flag
 from .support_operators import get_grid_coords
 
 
@@ -217,7 +219,25 @@ def vref_rot2geolatlon(
     grid = get_grid(u.geography)
     lon, lat = rot2geolatlon(grid)
     u_g, v_g = _vref_rot2geolatlon(u, v, lon, lat, grid)
-    return xr.DataArray(u_g, attrs=u.attrs), xr.DataArray(v_g, attrs=v.attrs)
+
+    # bit 5 left unset since u/v relative to grid in x (i) and y (j) directions,
+    # not defined grid; bit 3 and 5 set as i, j direction increments given
+    resolution_components_flags = set_code_flag([3, 4])
+
+    return (
+        xr.DataArray(
+            u_g,
+            attrs=metadata.override(
+                u.message, resolutionAndComponentFlags=resolution_components_flags
+            ),
+        ),
+        xr.DataArray(
+            v_g,
+            attrs=metadata.override(
+                v.message, resolutionAndComponentFlags=resolution_components_flags
+            ),
+        ),
+    )
 
 
 def _vref_rot2geolatlon(

--- a/tests/test_meteodatalab/test_gis.py
+++ b/tests/test_meteodatalab/test_gis.py
@@ -1,4 +1,8 @@
+# Standard library
+import io
+
 # Third-party
+import earthkit.data as ekd
 import numpy as np
 import pytest
 import xarray as xr
@@ -50,6 +54,12 @@ def test_vref_rot2geolatlon(data_dir, fieldextra):
 
     u_g, v_g = gis.vref_rot2geolatlon(ds["U_10M"], ds["V_10M"])
 
+    stream = io.BytesIO(u_g.message)
+    [grib_field] = ekd.from_source("stream", stream)
+    assert grib_decoder.get_code_flag(
+        grib_field.metadata().get("resolutionAndComponentFlags"),
+        [3, 4, 5],
+    ) == [True, True, False]
     fx_ds = fieldextra("n2geog")
 
     assert_allclose(u_g.isel(z=0), fx_ds["U_10M"], atol=1e-5, rtol=1e-6)

--- a/tests/test_meteodatalab/test_gis.py
+++ b/tests/test_meteodatalab/test_gis.py
@@ -1,8 +1,4 @@
-# Standard library
-import io
-
 # Third-party
-import earthkit.data as ekd
 import numpy as np
 import pytest
 import xarray as xr
@@ -10,7 +6,7 @@ from numpy.testing import assert_allclose
 
 # First-party
 from meteodatalab import grib_decoder
-from meteodatalab.metadata import set_origin_xy
+from meteodatalab.metadata import extract_keys, set_origin_xy
 from meteodatalab.operators import gis
 
 
@@ -54,10 +50,8 @@ def test_vref_rot2geolatlon(data_dir, fieldextra):
 
     u_g, v_g = gis.vref_rot2geolatlon(ds["U_10M"], ds["V_10M"])
 
-    stream = io.BytesIO(u_g.message)
-    [grib_field] = ekd.from_source("stream", stream)
     assert grib_decoder.get_code_flag(
-        grib_field.metadata().get("resolutionAndComponentFlags"),
+        extract_keys(u_g.message, "resolutionAndComponentFlags"),
         [3, 4, 5],
     ) == [True, True, False]
     fx_ds = fieldextra("n2geog")


### PR DESCRIPTION
## Purpose
Update the metadata `Resolution and component flags` of the `vref_rot2geolatlon` function in the GIS operator.

### Description
The `vref_rot2geolatlon` function changes the grid from which the u and v components of vector quantities are relative. According to [ECMWF GRIB Table](https://codes.ecmwf.int/grib/format/grib2/ftables/3/3/), bit N°5 must be changed from 1 to 0.