### PR TITLE
update metadata RELHUM

### DIFF
--- a/src/meteodatalab/operators/atmo.py
+++ b/src/meteodatalab/operators/atmo.py
@@ -12,12 +12,12 @@ def pv_sw(t):
 
     Parameters
     ----------
-    t : xr.DataArray
+    t : xarray.DataArray
         temperature (in Kelvin)
 
     Returns
     -------
-    xr.DataArray
+    xarray.DataArray
         pressure of water vapor in Pascal
 
     """
@@ -29,12 +29,12 @@ def pv_si(t):
 
     Parameters
     ----------
-    t : xr.DataArray
+    t : xarray.DataArray
         temperature (in Kelvin)
 
     Returns
     -------
-    xr.DataArray
+    xarray.DataArray
         pressure of water vapor in Pascal
 
     """
@@ -46,29 +46,24 @@ def pv_sm(t):
 
     Parameters
     ----------
-    t : xr.DataArray
+    t : xarray.DataArray
         temperature (in Kelvin)
 
     Returns
     -------
-    xr.DataArray
+    xarray.DataArray
         pressure of water vapor in Pascal
 
     """
     tice_only = pc.b3 - 23
     dtice = pc.b3 - tice_only
+    alpha = ((t - tice_only) / dtice) ** 2
 
-    if t > pc.b3:
-        # Liquid water only
-        pv_sm = pv_sw(t)
-    elif t < tice_only:
-        # Ice only
-        pv_sm = pv_si(t)
-    else:
-        #  Mixed phase
-        #  interpolation coefficient (function of T) between liquid and ice sat formula
-        alpha = ((t - tice_only) / dtice) ** 2
-        pv_sm = alpha * pv_sw(t) + (1.0 - alpha) * pv_si(t)
+    pv_sm = np.where(
+        t > pc.b3,
+        pv_sw(t),
+        np.where(t < tice_only, pv_si(t), alpha * pv_sw(t) + (1.0 - alpha) * pv_si(t)),
+    )
     return pv_sm
 
 
@@ -77,14 +72,14 @@ def qv_pvp(pv, p):
 
     Parameters
     ----------
-    pv : xr.DataArray
+    pv : xarray.DataArray
         pressure of water vapor
-    p : xr.DataArray
+    p : xarray.DataArray
         pressure
 
     Returns
     -------
-    xr.DataArray
+    xarray.DataArray
         specific water vapor (dimensionless)
 
     """
@@ -96,14 +91,14 @@ def pv_qp(qv, p):
 
     Parameters
     ----------
-    qv : xr.DataArray
+    qv : xarray.DataArray
         water vapor mixing ratio
-    p : xr.DataArray
+    p : xarray.DataArray
         pressure
 
     Returns
     -------
-    xr.DataArray
+    xarray.DataArray
         partial pressure of water vapor (same unit as p)
 
     """

--- a/src/meteodatalab/operators/atmo.py
+++ b/src/meteodatalab/operators/atmo.py
@@ -24,6 +24,54 @@ def pv_sw(t):
     return pc.b1 * np.exp(pc.b2w * (t - pc.b3) / (t - pc.b4w))
 
 
+def pv_si(t):
+    """Pressure of water vapor at equilibrium over ice.
+
+    Parameters
+    ----------
+    t : xr.DataArray
+        temperature (in Kelvin)
+
+    Returns
+    -------
+    xr.DataArray
+        pressure of water vapor in Pascal
+
+    """
+    return pc.b1 * np.exp(pc.b2i * (t - pc.b3) / (t - pc.b4i))
+
+
+def pv_sm(t):
+    """Pressure of water vapor at equilibrium over mixed phase.
+
+    Parameters
+    ----------
+    t : xr.DataArray
+        temperature (in Kelvin)
+
+    Returns
+    -------
+    xr.DataArray
+        pressure of water vapor in Pascal
+
+    """
+    tice_only = pc.b3 - 23
+    dtice = pc.b3 - tice_only
+
+    if t > pc.b3:
+        # Liquid water only
+        pv_sm = pv_sw(t)
+    elif t < tice_only:
+        # Ice only
+        pv_sm = pv_si(t)
+    else:
+        #  Mixed phase
+        #  interpolation coefficient (function of T) between liquid and ice sat formula
+        alpha = ((t - tice_only) / dtice) ** 2
+        pv_sm = alpha * pv_sw(t) + (1.0 - alpha) * pv_si(t)
+    return pv_sm
+
+
 def qv_pvp(pv, p):
     """Specific water vapor content (from perfect gas law and approximating q~w).
 

--- a/src/meteodatalab/operators/atmo.py
+++ b/src/meteodatalab/operators/atmo.py
@@ -58,12 +58,10 @@ def pv_sm(t):
     tice_only = pc.b3 - 23
     dtice = pc.b3 - tice_only
     alpha = ((t - tice_only) / dtice) ** 2
-
-    pv_sm = np.where(
-        t > pc.b3,
-        pv_sw(t),
-        np.where(t < tice_only, pv_si(t), alpha * pv_sw(t) + (1.0 - alpha) * pv_si(t)),
-    )
+    water = pv_sw(t)
+    ice = pv_si(t)
+    mix = alpha * water + (1.0 - alpha) * ice
+    pv_sm = water.where(t > pc.b3, ice.where(t < tice_only, mix))
     return pv_sm
 
 

--- a/src/meteodatalab/operators/relhum.py
+++ b/src/meteodatalab/operators/relhum.py
@@ -43,15 +43,15 @@ def relhum(
     max = 100 if clipping else None
 
     phase_conditions = {
-        "water": {"func": pv_sw, "shortName": "RELHUM"},
-        "ice": {"func": pv_si, "shortName": "RH_ICE"},
-        "water+ice": {"func": pv_sm, "shortName": "RH_MIX_EC"},
+        "water": {"func": pv_sw(t), "shortName": "RELHUM"},
+        "ice": {"func": pv_si(t), "shortName": "RH_ICE"},
+        "water+ice": {"func": pv_sm(t), "shortName": "RH_MIX_EC"},
     }
 
     if phase not in phase_conditions:
         raise ValueError("Invalid phase. Phase must be 'water', 'ice', or 'water+ice'.")
 
-    result = (100.0 * qv / qv_pvp(phase_conditions[phase]["func"](t), p)).clip(0, max)
+    result = (100.0 * qv / qv_pvp(phase_conditions[phase]["func"], p)).clip(0, max)
 
     return xr.DataArray(
         data=result,

--- a/src/meteodatalab/operators/relhum.py
+++ b/src/meteodatalab/operators/relhum.py
@@ -6,8 +6,9 @@ from typing import Literal
 # Third-party
 import xarray as xr
 
-# First-party
-from meteodatalab.operators.atmo import pv_sw, qv_pvp
+# Local
+from .. import metadata
+from .atmo import pv_sw, qv_pvp
 
 
 def relhum(
@@ -17,12 +18,12 @@ def relhum(
 
     Parameters
     ----------
-    qv : xr.DataArray
+    qv : xarray.DataArray
         water vapor mixing ratio
-    t : xr.DataArray
-        temperature
-    p : xr.DataArray
-        pressure
+    t : xarray.DataArray
+        temperature in Kelvin
+    p : xarray.DataArray
+        pressure in Pa
     clipping : bool
         clips the relative humidity to [0,100] interval.
         Only upper bound is controlled by this parameter,
@@ -35,13 +36,15 @@ def relhum(
 
     Returns
     -------
-    xr.DataArray
-        relative humidity field
+    xarray.DataArray
+        relative humidity field in %
 
     """
     if phase != "water":
         raise ValueError(f"{phase=} not implemented")
-    attrs = t.attrs.copy()
     max = 100 if clipping else None
 
-    return xr.DataArray((100.0 * qv / qv_pvp(pv_sw(t), p)).clip(0, max), attrs=attrs)
+    return xr.DataArray(
+        data=(100.0 * qv / qv_pvp(pv_sw(t), p)).clip(0, max),
+        attrs=metadata.override(t.message, shortName="RELHUM"),
+    )

--- a/src/meteodatalab/physical_constants.py
+++ b/src/meteodatalab/physical_constants.py
@@ -16,9 +16,11 @@ rvd_o = rvd - 1.0
 # saturation vapour pressure (Tetens's formula, see
 # http://www.ecmwf.int/sites/default/files/elibrary/2015/9208-part-i-observation-processing.pdf)
 b1 = 611.21  # Pressure at triple point of water [Pa]
-b2w = 17.502
+b2w = 17.502  # over water
+b2i = 22.587  # over ice
 b3 = 273.16  # Temperature at triple point of water [K]
-b4w = 32.19  # [K]
+b4w = 32.19  # [K] over water
+b4i = -0.7  # [K] over ice
 
 # Surface pressure reference for omega slope
 surface_pressure_ref = 101325.0  # [Pa]

--- a/tests/test_meteodatalab/fieldextra_templates/test_RELHUM.nl
+++ b/tests/test_meteodatalab/fieldextra_templates/test_RELHUM.nl
@@ -47,5 +47,5 @@
 &Process in_field="P", levmin=1, levmax=80 /
 &Process in_field="T", levmin=1, levmax=80 /
 &Process in_field="QV", levmin=1, levmax=80 /
-&Process out_field="RELHUM", levmin=1, levmax=80 /
+&Process out_field="{{ field }}", levmin=1, levmax=80 /
 

--- a/tests/test_meteodatalab/test_relhum.py
+++ b/tests/test_meteodatalab/test_relhum.py
@@ -1,28 +1,56 @@
 # Third-party
+import pytest
 from numpy.testing import assert_allclose
 
 # First-party
 from meteodatalab.grib_decoder import GribReader
 from meteodatalab.operators.relhum import relhum
 
+expected_water = {
+    "centre": "lssw",
+    "paramId": 500037,
+    "shortName": "RELHUM",
+    "units": "%",
+    "name": "Relative Humidity",
+}
 
-def test_relhum(data_dir, fieldextra):
+expected_ice = {
+    "centre": "lssw",
+    "paramId": 503195,
+    "shortName": "RH_ICE",
+    "units": "%",
+    "name": "relative humidity over ice",
+}
+expected_mixed = {
+    "centre": "lssw",
+    "paramId": 503078,
+    "shortName": "RH_MIX_EC",
+    "units": "%",
+    "name": "Relative humidity over mixed phase",
+}
+
+
+@pytest.mark.parametrize(
+    "phase,field,expected",
+    [
+        ("water", "RELHUM", expected_water),
+        ("ice", "RH_ICE", expected_ice),
+        ("water+ice", "RH_MIX_EC", expected_mixed),
+    ],
+)
+def test_relhum(data_dir, fieldextra, phase, field, expected):
     datafile = data_dir / "COSMO-1E/1h/ml_sl/000/lfff00000000"
     cdatafile = data_dir / "COSMO-1E/1h/const/000/lfff00000000c"
 
     reader = GribReader.from_files([cdatafile, datafile])
     ds = reader.load_fieldnames(["P", "T", "QV"])
 
-    relhum_arr = relhum(ds["QV"], ds["T"], ds["P"], clipping=True, phase="water")
+    relhum_arr = relhum(ds["QV"], ds["T"], ds["P"], clipping=True, phase=phase)
+    if phase == "water+ice":
+        print("relhum_arr")
+        print(relhum_arr)
+        print(relhum_arr.parameter)
+    assert relhum_arr.parameter == expected
 
-    assert relhum_arr.parameter == {
-        "centre": "lssw",
-        "paramId": 500037,
-        "shortName": "RELHUM",
-        "units": "%",
-        "name": "Relative Humidity",
-    }
-
-    fs_ds = fieldextra("RELHUM")
-
-    assert_allclose(fs_ds["RELHUM"], relhum_arr, rtol=5e-3, atol=5e-2)
+    fs_ds = fieldextra("RELHUM", field=field)
+    assert_allclose(fs_ds[field], relhum_arr, rtol=5e-3, atol=5e-2)

--- a/tests/test_meteodatalab/test_relhum.py
+++ b/tests/test_meteodatalab/test_relhum.py
@@ -15,6 +15,14 @@ def test_relhum(data_dir, fieldextra):
 
     relhum_arr = relhum(ds["QV"], ds["T"], ds["P"], clipping=True, phase="water")
 
+    assert relhum_arr.parameter == {
+        "centre": "lssw",
+        "paramId": 500037,
+        "shortName": "RELHUM",
+        "units": "%",
+        "name": "Relative Humidity",
+    }
+
     fs_ds = fieldextra("RELHUM")
 
     assert_allclose(fs_ds["RELHUM"], relhum_arr, rtol=5e-3, atol=5e-2)

--- a/tests/test_meteodatalab/test_relhum.py
+++ b/tests/test_meteodatalab/test_relhum.py
@@ -46,10 +46,6 @@ def test_relhum(data_dir, fieldextra, phase, field, expected):
     ds = reader.load_fieldnames(["P", "T", "QV"])
 
     relhum_arr = relhum(ds["QV"], ds["T"], ds["P"], clipping=True, phase=phase)
-    if phase == "water+ice":
-        print("relhum_arr")
-        print(relhum_arr)
-        print(relhum_arr.parameter)
     assert relhum_arr.parameter == expected
 
     fs_ds = fieldextra("RELHUM", field=field)


### PR DESCRIPTION
## Purpose

- Update metadata of `relhum` operator.
- Add `ice` and `water+ice` phases next to `water` to the `relhum` operator.
### Note
Metadata for relative humidity in mixed phase (water+ice) `RH_MIX_EC` is defined in a local code here: https://github.com/COSMO-ORG/fieldextra/blob/develop/resources/dictionary_cosmo.txt#L2038 but points to parameter 220 which corresponds to `Minimum specific humidity at 2m` here: https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table4-2-0-1.shtml.
We decide to keep this metadata definition for the moment.
