### PR TITLE
Implement iconremap

### DIFF
--- a/jenkins/icontools/Jenkinsfile
+++ b/jenkins/icontools/Jenkinsfile
@@ -3,6 +3,10 @@ pipeline {
         label 'balfrin'
     }
 
+    options {
+        overrideIndexTriggers(false)
+    }
+
     environment {
         MAMBA_ROOT_PREFIX="$WORKSPACE/micromamba"
         MICROMAMBA_INSTALL_PATH="$SCRATCH/mch_jenkins_node/tools/micromamba"

--- a/jenkins/icontools/Jenkinsfile
+++ b/jenkins/icontools/Jenkinsfile
@@ -3,18 +3,19 @@ pipeline {
         label 'balfrin'
     }
 
+    environment {
+        MAMBA_ROOT_PREFIX="$WORKSPACE/micromamba"
+    }
+
     post {
         always{
             echo 'Cleaning up workspace'
             deleteDir()
         }
     }
+
     stages {
         stage('build') {
-            environment {
-                PATH="$SCRATCH/mch_jenkins_node/tools/micromamba/bin:$PATH"
-                MAMBA_ROOT_PREFIX="$WORKSPACE/micromamba"
-            }
             steps {
                 sh '''#!/usr/bin/env bash
                 set -ex
@@ -24,8 +25,16 @@ pipeline {
                 cd dwd_icon_tools
                 micromamba create -n icontools conda-build -c conda-forge
                 micromamba activate icontools
-                echo $CONDA_PREFIX
                 conda-build -c conda-forge config/conda -m $WORKSPACE/jenkins/icontools/conda_build_config.yaml
+                micromamba install -c file://${CONDA_PREFIX}/conda-bld -c conda-forge iconremap
+                '''
+            }
+        }
+        stage('export') {
+            steps {
+                sh '''#!/usr/bin/env bash
+                set -ex
+                micromamba run -n icontools python $WORKSPACE/jenkins/icontools/export_coeffs.py
                 '''
             }
         }

--- a/jenkins/icontools/Jenkinsfile
+++ b/jenkins/icontools/Jenkinsfile
@@ -37,6 +37,8 @@ pipeline {
                 eval "$(${MICROMAMBA_INSTALL_PATH}/bin/micromamba shell hook -s posix)"
                 micromamba run -n icontools python $WORKSPACE/jenkins/icontools/export_coeffs.py
                 '''
+                echo 'Collecting artifacts'
+                archiveArtifacts artifacts: 'output/*.nc', fingerprint: true
             }
         }
     }

--- a/jenkins/icontools/Jenkinsfile
+++ b/jenkins/icontools/Jenkinsfile
@@ -5,6 +5,7 @@ pipeline {
 
     environment {
         MAMBA_ROOT_PREFIX="$WORKSPACE/micromamba"
+        MICROMAMBA_INSTALL_PATH="$SCRATCH/mch_jenkins_node/tools/micromamba"
     }
 
     post {
@@ -19,8 +20,7 @@ pipeline {
             steps {
                 sh '''#!/usr/bin/env bash
                 set -ex
-                micromamba_install_path=$SCRATCH/mch_jenkins_node/tools/micromamba
-                eval "$(${micromamba_install_path}/bin/micromamba shell hook -s posix)"
+                eval "$(${MICROMAMBA_INSTALL_PATH}/bin/micromamba shell hook -s posix)"
                 git clone --depth 1 --recurse-submodules git@gitlab.dkrz.de:dwd-sw/dwd_icon_tools.git
                 cd dwd_icon_tools
                 micromamba create -n icontools conda-build -c conda-forge
@@ -34,6 +34,7 @@ pipeline {
             steps {
                 sh '''#!/usr/bin/env bash
                 set -ex
+                eval "$(${MICROMAMBA_INSTALL_PATH}/bin/micromamba shell hook -s posix)"
                 micromamba run -n icontools python $WORKSPACE/jenkins/icontools/export_coeffs.py
                 '''
             }

--- a/jenkins/icontools/Jenkinsfile
+++ b/jenkins/icontools/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
                 micromamba create -n icontools conda-build -c conda-forge
                 micromamba activate icontools
                 echo $CONDA_PREFIX
-                conda-build -c conda-forge config/conda
+                conda-build -c conda-forge config/conda -m $WORKSPACE/jenkins/icontools/conda_build_config.yaml
                 '''
             }
         }

--- a/jenkins/icontools/Jenkinsfile
+++ b/jenkins/icontools/Jenkinsfile
@@ -1,0 +1,33 @@
+pipeline {
+    agent {
+        label 'balfrin'
+    }
+
+    post {
+        always{
+            echo 'Cleaning up workspace'
+            deleteDir()
+        }
+    }
+    stages {
+        stage('build') {
+            environment {
+                PATH="$SCRATCH/mch_jenkins_node/tools/micromamba/bin:$PATH"
+                MAMBA_ROOT_PREFIX="$WORKSPACE/micromamba"
+            }
+            steps {
+                sh '''#!/usr/bin/env bash
+                set -ex
+                micromamba_install_path=$SCRATCH/mch_jenkins_node/tools/micromamba
+                eval "$(${micromamba_install_path}/bin/micromamba shell hook -s posix)"
+                git clone --depth 1 git@gitlab.dkrz.de:dwd-sw/dwd_icon_tools.git
+                cd dwd_icon_tools
+                micromamba create -n icontools conda-build -c conda-forge
+                micromamba activate icontools
+                echo $CONDA_PREFIX
+                conda-build -c conda-forge config/conda
+                '''
+            }
+        }
+    }
+}

--- a/jenkins/icontools/Jenkinsfile
+++ b/jenkins/icontools/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
                 set -ex
                 micromamba_install_path=$SCRATCH/mch_jenkins_node/tools/micromamba
                 eval "$(${micromamba_install_path}/bin/micromamba shell hook -s posix)"
-                git clone --depth 1 git@gitlab.dkrz.de:dwd-sw/dwd_icon_tools.git
+                git clone --depth 1 --recurse-submodules git@gitlab.dkrz.de:dwd-sw/dwd_icon_tools.git
                 cd dwd_icon_tools
                 micromamba create -n icontools conda-build -c conda-forge
                 micromamba activate icontools

--- a/jenkins/icontools/README.md
+++ b/jenkins/icontools/README.md
@@ -1,0 +1,9 @@
+# icontools
+
+The [DWD icon tools](https://gitlab.dkrz.de/dwd-sw/dwd_icon_tools) are used to precompute the interpolation weights for the icon remap functionality.
+Grid configurations are extracted from the current operational configuration at Meteoswiss.
+
+## Jenkins pipeline
+
+The pipeline is deployed to the following location:
+https://jenkins-mch.cscs.ch/job/IconDataProcessing/job/icontools/

--- a/jenkins/icontools/conda_build_config.yaml
+++ b/jenkins/icontools/conda_build_config.yaml
@@ -1,0 +1,4 @@
+c_compiler_version:
+    - 11.3.0
+cxx_compiler_version:
+    - 11.3.0

--- a/jenkins/icontools/export_coeffs.py
+++ b/jenkins/icontools/export_coeffs.py
@@ -3,11 +3,11 @@ import dataclasses as dc
 from pathlib import Path
 
 # Third-party
+import click
 import pyremap.iconremap as ir
 import pyremap.regular_grid as rg
 import xarray as xr
 import yaml
-import click
 
 DEFAULTS = {
     "models": "icon-ch1-eps,icon-ch2-eps",

--- a/jenkins/icontools/export_coeffs.py
+++ b/jenkins/icontools/export_coeffs.py
@@ -1,0 +1,128 @@
+# Standard library
+import dataclasses as dc
+from pathlib import Path
+
+# Third-party
+import pyremap.iconremap as ir
+import pyremap.regular_grid as rg
+import xarray as xr
+import yaml
+import click
+
+DEFAULTS = {
+    "models": "icon-ch1-eps,icon-ch2-eps",
+    "dst_grids": "rotlatlon,geolatlon",
+    "grid_config_path": Path(__file__).parent / "grid_config.yaml",
+}
+GRID_DIR = Path("/scratch/mch/jenkins/icon/pool/data/ICON/mch/grids")
+INPUT_GRIDS = {
+    "icon-ch1-eps": GRID_DIR / "icon-1/icon_grid_0001_R19B08_mch.nc",
+    "icon-ch2-eps": GRID_DIR / "icon-2/icon_grid_0002_R19B07_mch.nc",
+}
+
+
+def split_arg(ctx, param, value):
+    return [item.trim() for item in value.split()]
+
+
+@click.command()
+@click.option(
+    "--models",
+    type=str,
+    default=DEFAULTS["models"],
+    callback=split_arg,
+    help="Comma separated list of models for which to produce indices and weights.",
+)
+@click.option(
+    "--dst-grids",
+    type=str,
+    default=DEFAULTS["dst_grids"],
+    callback=split_arg,
+    help="Comma separated list of destination grids "
+    "for which to produce indices and weights.",
+)
+@click.option(
+    "--grid-config-path",
+    type=click.Path(path_type=Path),
+    default=DEFAULTS["grid_config_path"],
+    help="Path to the grid configuration file.",
+)
+def main(models, dst_grids, grid_config_path):
+    cfg = read_grid_config(grid_config_path)
+    for model in models:
+        for dst_grid in dst_grids:
+            key = f"{model}-{dst_grid}"
+            dst = Grid(**cfg[model][dst_grid])
+            input_grid_path = INPUT_GRIDS[model]
+            write_coeffs(input_grid_path, key, dst)
+
+
+@dc.dataclass
+class Grid:
+    dx: float
+    dy: float
+    xmin: float
+    xmax: float
+    ymin: float
+    ymax: float
+    north_pole_lon: float | None = None
+    north_pole_lat: float | None = None
+
+    @property
+    def nx(self):
+        return round((self.xmax - self.xmin) / self.dx + 1)
+
+    @property
+    def ny(self):
+        return round((self.ymax - self.ymin) / self.dy + 1)
+
+    @property
+    def north_pole(self):
+        return self.north_pole_lon, self.north_pole_lat
+
+
+def read_grid_config(config_path: Path):
+    with config_path.open() as f:
+        return yaml.safe_load(f)
+
+
+def write_coeffs(input_grid_path: Path, key: str, dst: Grid) -> None:
+    fields = [("VN", "U,V", "rbf")]
+    inds = xr.open_dataset(input_grid_path, engine="netcdf4")
+    sg = rg.RegularLatLonGrid(
+        dst.nx,
+        dst.ny,
+        (dst.xmin, dst.ymin),
+        (dst.xmax, dst.ymax),
+        dst.north_pole,
+    )
+    coeffs = ir.compute_icon_grid_coeffs(
+        5,
+        sgrid=sg,
+        ingrid_ds=inds,
+        outgrid_type="local-reg",
+        fields=fields,
+    )
+    names = [
+        f"rbf{prefix}B{suffix}"
+        for prefix in ("_", "_u_vn_", "_v_vn_")
+        for suffix in ("_wgt", "_glbidx")
+    ]
+    output = coeffs[names]
+    output.attrs = {
+        "xmin": dst.xmin,
+        "xmax": dst.xmax,
+        "ymin": dst.ymin,
+        "ymax": dst.ymax,
+        "nx": dst.nx,
+        "ny": dst.ny,
+        "dx": dst.dx,
+        "dy": dst.dy,
+        "north_pole_lon": dst.north_pole_lon,
+        "north_pole_lat": dst.north_pole_lat,
+    }
+    output.to_netcdf(f"output/{key}.nc")
+
+
+if __name__ == "__main__":
+    main()

--- a/jenkins/icontools/export_coeffs.py
+++ b/jenkins/icontools/export_coeffs.py
@@ -22,7 +22,7 @@ INPUT_GRIDS = {
 
 
 def split_arg(ctx, param, value: str):
-    return [item.strip() for item in value.split()]
+    return [item.strip() for item in value.split(",")]
 
 
 @click.command()

--- a/jenkins/icontools/export_coeffs.py
+++ b/jenkins/icontools/export_coeffs.py
@@ -21,8 +21,8 @@ INPUT_GRIDS = {
 }
 
 
-def split_arg(ctx, param, value):
-    return [item.trim() for item in value.split()]
+def split_arg(ctx, param, value: str):
+    return [item.strip() for item in value.split()]
 
 
 @click.command()

--- a/jenkins/icontools/export_coeffs.py
+++ b/jenkins/icontools/export_coeffs.py
@@ -48,6 +48,7 @@ def split_arg(ctx, param, value: str):
     help="Path to the grid configuration file.",
 )
 def main(models, dst_grids, grid_config_path):
+    Path("output").mkdir(exist_ok=True)
     cfg = read_grid_config(grid_config_path)
     for model in models:
         for dst_grid in dst_grids:
@@ -65,8 +66,8 @@ class Grid:
     xmax: float
     ymin: float
     ymax: float
-    north_pole_lon: float | None = None
-    north_pole_lat: float | None = None
+    north_pole_lon: float = -180.0
+    north_pole_lat: float = 90.0
 
     @property
     def nx(self):
@@ -108,7 +109,12 @@ def write_coeffs(input_grid_path: Path, key: str, dst: Grid) -> None:
         for prefix in ("_", "_u_vn_", "_v_vn_")
         for suffix in ("_wgt", "_glbidx")
     ]
-    output = coeffs[names]
+    n = dst.nx * dst.ny
+    output = coeffs[names].isel(
+        rbf_B_stencil_size=slice(n),
+        rbf_u_vn_B_stencil_size=slice(n),
+        rbf_v_vn_B_stencil_size=slice(n),
+    )
     output.attrs = {
         "xmin": dst.xmin,
         "xmax": dst.xmax,

--- a/jenkins/icontools/grid_config.yaml
+++ b/jenkins/icontools/grid_config.yaml
@@ -1,0 +1,35 @@
+icon-ch1-eps:
+  rotlatlon:
+    dx: 0.01
+    dy: 0.01
+    xmin: -6.86
+    xmax: 4.83
+    ymin: -4.46
+    ymax: 3.39
+    north_pole_lon: 190.0
+    north_pole_lat: 43.0
+  geolatlon:
+    dx: 0.01
+    dy: 0.01
+    xmin: 10.0
+    xmax: 13.0
+    ymin: 45.6
+    ymax: 47.8
+
+icon-ch2-eps:
+  rotlatlon:
+    dx: 0.02
+    dy: 0.02
+    xmin: -6.82
+    xmax: 4.8
+    ymin: -4.42
+    ymax: 3.36
+    north_pole_lon: 190.0
+    north_pole_lat: 43.0
+  geolatlon:
+    dx: 0.02
+    dy: 0.02
+    xmin: 5.5
+    xmax: 16.9
+    ymin: 43.6
+    ymax: 50.0

--- a/src/meteodatalab/grib_decoder.py
+++ b/src/meteodatalab/grib_decoder.py
@@ -162,9 +162,6 @@ class _FieldBuffer:
         return coords, shape
 
     def to_xarray(self) -> xr.DataArray:
-        if self.dims is None:
-            raise RuntimeError("No dims.")
-
         if not self.values:
             raise MissingData("No values.")
 

--- a/src/meteodatalab/grib_decoder.py
+++ b/src/meteodatalab/grib_decoder.py
@@ -21,7 +21,7 @@ import xarray as xr
 from numpy.typing import DTypeLike
 
 # Local
-from . import data_source, mars, metadata, tasking
+from . import data_source, icon_grid, mars, metadata, tasking
 
 logger = logging.getLogger(__name__)
 
@@ -81,6 +81,16 @@ def _is_ensemble(field) -> bool:
         return False
 
 
+def _get_hcoords(field):
+    if field.metadata("gridType") == "unstructured_grid":
+        grid_uuid = field.metadata("uuidOfHGrid")
+        return icon_grid.get_icon_grid(grid_uuid)
+    return {
+        dim: xr.DataArray(dims=("y", "x"), data=values)
+        for dim, values in field.to_latlon().items()
+    }
+
+
 def _parse_datetime(date, time) -> dt.datetime:
     return dt.datetime.strptime(f"{date}{time:04d}", "%Y%m%d%H%M")
 
@@ -126,15 +136,12 @@ class _FieldBuffer:
 
         if not self.metadata:
             self.metadata = {
-                "message": field.message(),
+                "message": field.message(),  # try field.metadata.override()
                 **metadata.extract(field.metadata()),
             }
 
         if not self.hcoords:
-            self.hcoords = {
-                dim: xr.DataArray(dims=("y", "x"), data=values)
-                for dim, values in field.to_latlon().items()
-            }
+            self.hcoords = _get_hcoords(field)
 
     def _gather_coords(self):
         coord_values = zip(*self.values)
@@ -150,11 +157,14 @@ class _FieldBuffer:
             logger.exception(msg)
             raise RuntimeError(msg)
 
-        ny, nx = next(iter(self.values.values())).shape
-        shape = tuple(len(v) for v in coords.values()) + (ny, nx)
+        field_shape = next(iter(self.values.values())).shape
+        shape = tuple(len(v) for v in coords.values()) + field_shape
         return coords, shape
 
     def to_xarray(self) -> xr.DataArray:
+        if self.dims is None:
+            raise RuntimeError("No dims.")
+
         if not self.values:
             raise MissingData("No values.")
 
@@ -162,13 +172,14 @@ class _FieldBuffer:
         ref_time = xr.DataArray(coords["ref_time"], dims="ref_time")
         lead_time = xr.DataArray(coords["lead_time"], dims="lead_time")
         tcoords = {"valid_time": ref_time + lead_time}
+        hdims = self.hcoords["lon"].dims
 
         array = xr.DataArray(
             data=np.array(
                 [self.values.pop(key) for key in sorted(self.values)]
             ).reshape(shape),
             coords=coords | self.hcoords | tcoords,
-            dims=self.dims + ("y", "x"),
+            dims=self.dims + hdims,
             attrs=self.metadata,
         )
 

--- a/src/meteodatalab/icon_grid.py
+++ b/src/meteodatalab/icon_grid.py
@@ -1,0 +1,28 @@
+from uuid import UUID
+from pathlib import Path
+
+import numpy as np
+import xarray as xr
+
+GRID_ID = {
+    "icon-ch1-eps": UUID("17643da2-5749-59b6-44d2-54a3cd6e2bc0"),
+    "icon-ch2-eps": UUID("bbbd5a09-8554-9924-3c7a-4aa4c8762920"),
+}
+GRID_DIR = Path("/scratch/mch/jenkins/icon/pool/data/ICON/mch/grids/")
+GRID_MAP = {
+    GRID_ID["icon-ch1-eps"]: GRID_DIR / "icon-1/icon_grid_0001_R19B08_mch.nc",
+    GRID_ID["icon-ch2-eps"]: GRID_DIR / "icon-2/icon_grid_0002_R19B07_mch.nc",
+}
+
+
+def get_icon_grid(grid_uuid: str):
+    grid_path = GRID_MAP.get(UUID(grid_uuid))
+
+    if grid_path is None:
+        raise KeyError
+
+    ds = xr.open_dataset(grid_path)
+
+    rad2deg = 180 / np.pi
+    result = ds[["clon", "clat"]].reset_coords() * rad2deg
+    return {"lon": result.clon, "lat": result.clat}

--- a/src/meteodatalab/icon_grid.py
+++ b/src/meteodatalab/icon_grid.py
@@ -26,3 +26,9 @@ def get_icon_grid(grid_uuid: str):
     rad2deg = 180 / np.pi
     result = ds[["clon", "clat"]].reset_coords() * rad2deg
     return {"lon": result.clon, "lat": result.clat}
+
+
+def get_remap_coeffs(grid_uuid: str):
+    model = {v.hex: k for k, v in GRID_ID.items()}[grid_uuid]
+    coeffs_path = f"/store_new/mch/msopr/icon_workflow_2/iconremap-weights/{model}.nc"
+    return xr.open_dataset(coeffs_path)

--- a/src/meteodatalab/icon_grid.py
+++ b/src/meteodatalab/icon_grid.py
@@ -17,7 +17,25 @@ GRID_MAP = {
 }
 
 
-def get_icon_grid(grid_uuid: str):
+def get_icon_grid(grid_uuid: str) -> dict[str, xr.DataArray]:
+    """Get ICON native grid coordinates.
+
+    Parameters
+    ----------
+    grid_uuid : str
+        The UUID of the horizontal grid.
+
+    Raises
+    ------
+    KeyError
+        If the UUID is not found in the GRID_MAP constant.
+
+    Returns
+    -------
+    dict[str, xarray.DataArray]
+        Geodectic coordinates of the ICON grid cell centers.
+
+    """
     grid_path = GRID_MAP.get(UUID(grid_uuid))
 
     if grid_path is None:
@@ -30,7 +48,25 @@ def get_icon_grid(grid_uuid: str):
     return {"lon": result.clon, "lat": result.clat}
 
 
-def get_remap_coeffs(grid_uuid: str):
+def get_remap_coeffs(grid_uuid: str) -> xr.Dataset:
+    """Get ICON native grid remap indices and weights.
+
+    Parameters
+    ----------
+    grid_uuid : str
+        The UUID of the horizontal grid in hex format.
+
+    Raises
+    ------
+    KeyError
+        If the UUID is not found in the GRID_ID constant.
+
+    Returns
+    -------
+    xarray.Dataset
+        Dataset of the remap indices and weights.
+
+    """
     model = {v.hex: k for k, v in GRID_ID.items()}[grid_uuid]
     coeffs_path = f"/store_new/mch/msopr/icon_workflow_2/iconremap-weights/{model}.nc"
     return xr.open_dataset(coeffs_path)

--- a/src/meteodatalab/icon_grid.py
+++ b/src/meteodatalab/icon_grid.py
@@ -2,8 +2,8 @@
 
 # Standard library
 from pathlib import Path
-from uuid import UUID
 from typing import Literal
+from uuid import UUID
 
 # Third-party
 import numpy as np
@@ -60,6 +60,8 @@ def get_remap_coeffs(
     ----------
     grid_uuid : str
         The UUID of the horizontal grid in hex format.
+    grid_type : str
+        Type of grid to remap to.
 
     Raises
     ------

--- a/src/meteodatalab/icon_grid.py
+++ b/src/meteodatalab/icon_grid.py
@@ -1,3 +1,5 @@
+"""ICON native grid helper functions."""
+
 # Standard library
 from pathlib import Path
 from uuid import UUID

--- a/src/meteodatalab/icon_grid.py
+++ b/src/meteodatalab/icon_grid.py
@@ -1,6 +1,8 @@
-from uuid import UUID
+# Standard library
 from pathlib import Path
+from uuid import UUID
 
+# Third-party
 import numpy as np
 import xarray as xr
 

--- a/src/meteodatalab/icon_grid.py
+++ b/src/meteodatalab/icon_grid.py
@@ -3,6 +3,7 @@
 # Standard library
 from pathlib import Path
 from uuid import UUID
+from typing import Literal
 
 # Third-party
 import numpy as np
@@ -50,7 +51,9 @@ def get_icon_grid(grid_uuid: str) -> dict[str, xr.DataArray]:
     return {"lon": result.clon, "lat": result.clat}
 
 
-def get_remap_coeffs(grid_uuid: str) -> xr.Dataset:
+def get_remap_coeffs(
+    grid_uuid: str, grid_type: Literal["rotlatlon", "geolatlon"]
+) -> xr.Dataset:
     """Get ICON native grid remap indices and weights.
 
     Parameters
@@ -70,5 +73,7 @@ def get_remap_coeffs(grid_uuid: str) -> xr.Dataset:
 
     """
     model = {v.hex: k for k, v in GRID_ID.items()}[grid_uuid]
-    coeffs_path = f"/store_new/mch/msopr/icon_workflow_2/iconremap-weights/{model}.nc"
+    coeffs_path = (
+        f"/store_new/mch/msopr/icon_workflow_2/iconremap-weights/{model}-{grid_type}.nc"
+    )
     return xr.open_dataset(coeffs_path)

--- a/src/meteodatalab/metadata.py
+++ b/src/meteodatalab/metadata.py
@@ -22,9 +22,13 @@ VCOORD_TYPE = {
 
 
 def extract(metadata):
-    [vref_flag] = grib_decoder.get_code_flag(
-        metadata.get("resolutionAndComponentFlags"), [5]
-    )
+    if metadata.get("gridType") == "unstructured_grid":
+        vref_flag = False
+    else:
+        [vref_flag] = grib_decoder.get_code_flag(
+            metadata.get("resolutionAndComponentFlags"), [5]
+        )
+
     level_type = metadata.get("typeOfLevel")
     vcoord_type, zshift = VCOORD_TYPE.get(level_type, (level_type, 0.0))
 

--- a/src/meteodatalab/operators/regrid.py
+++ b/src/meteodatalab/operators/regrid.py
@@ -307,7 +307,20 @@ def regrid(
     return xr.DataArray(data, attrs=attrs)
 
 
-def icon2rotlatlon(field):
+def icon2rotlatlon(field: xr.DataArray) -> xr.DataArray:
+    """Remap ICON native grid data to the rotated latlon grid.
+
+    Parameters
+    ----------
+    field : xarray.DataArray
+        A field with data in the ICON native grid.
+
+    Returns
+    -------
+    xarray.DataArray
+        Field with data remapped to the rotated latlon grid.
+
+    """
     gid = metadata.extract_keys(field.message, "uuidOfHGrid")
     coeffs = icon_grid.get_remap_coeffs(gid)
     indices = coeffs["rbf_B_glbidx"].values
@@ -333,8 +346,8 @@ def icon2rotlatlon(field):
         values = np.take(field, indices, axis=-1)
         if np.any(np.isnan(values)):
             warnings.warn("Interpolation of missing values is not supported.")
-        vmin = np.nanmin(values, axis=-1)
-        vmax = np.nanmax(values, axis=-1)
+        vmin = np.min(values, axis=-1)
+        vmax = np.max(values, axis=-1)
         result = np.einsum("...ij,ij->...i", values, weights)
         return np.clip(result, vmin, vmax).reshape(out_shape)
 

--- a/src/meteodatalab/operators/regrid.py
+++ b/src/meteodatalab/operators/regrid.py
@@ -12,7 +12,7 @@ from rasterio import transform, warp
 from rasterio.crs import CRS
 
 # Local
-from .. import metadata, icon_grid
+from .. import icon_grid, metadata
 from ..grib_decoder import set_code_flag
 
 Resampling: typing.TypeAlias = warp.Resampling

--- a/tests/test_meteodatalab/conftest.py
+++ b/tests/test_meteodatalab/conftest.py
@@ -70,6 +70,8 @@ def data_dir(request, machine, unpack):
             return unpack(base_dir / "datasets/32_39x45_51") / "COSMO-1E_ens"
         case "flexpart":
             return base_dir / "data/flexpart"
+        case "iconremap":
+            return base_dir / "datasets/iconremap"
     raise RuntimeError(f"No match for data mark {marker.args[0]}")
 
 

--- a/tests/test_meteodatalab/fieldextra_templates/test_iconremap.nl
+++ b/tests/test_meteodatalab/fieldextra_templates/test_iconremap.nl
@@ -1,0 +1,45 @@
+&RunSpecification
+  strict_nl_parsing=.true.
+  verbosity="moderate"
+  diagnostic_length=110
+  soft_memory_limit=300.0
+/
+
+&GlobalResource
+  dictionary="{{ resources }}/dictionary_icon.txt"
+  grib_definition_path="{{ resources }}/eccodes_definitions_cosmo"
+                       "{{ resources }}/eccodes_definitions_vendor"
+  grib2_sample="{{ resources }}/eccodes_samples/COSMO_GRIB2_default.tmpl"
+  icon_grid_description="/oprusers/osm/opr.emme/data/ICON_INPUT/ICON-CH1-EPS/icon_grid_0001_R19B08_mch.nc"
+  rttov_coefs_path="{{ resources }}/rttov_coefficients"
+/
+
+&GlobalSettings
+  default_model_name="icon-ch1-eps"
+  default_out_type_stdlongitude=.true.
+  location_to_gridpoint="sn"
+/
+
+&ModelSpecification
+  model_name="icon-ch1-eps"
+  earth_axis_large=6371229.
+  earth_axis_small=6371229.
+  hydrometeor="QR", "QG", "QS"
+  precip_all="RAIN_GSP", "SNOW_GSP", "GRAU_GSP"
+  precip_snow="SNOW_GSP", "GRAU_GSP"
+  precip_rain="RAIN_GSP"
+  precip_convective=
+  precip_gridscale="RAIN_GSP", "SNOW_GSP", "GRAU_GSP"
+/
+
+&Process
+  in_file  = "{{ file.inputi }}"
+  tstart = 0, tstop = 0, tincr = 1
+  out_regrid_target = "rotlatlon,353140000,-4460000,4830000,3390000,10000,10000,190000000,43000000"
+  out_regrid_method = "icontools,rbf"
+  out_file = "{{ file.output }}"
+  out_type = "NETCDF"
+/
+&Process in_field="T", levmin=1, levmax=80 /
+&Process out_field="T" /
+

--- a/tests/test_meteodatalab/fieldextra_templates/test_iconremap.nl
+++ b/tests/test_meteodatalab/fieldextra_templates/test_iconremap.nl
@@ -10,18 +10,18 @@
   grib_definition_path="{{ resources }}/eccodes_definitions_cosmo"
                        "{{ resources }}/eccodes_definitions_vendor"
   grib2_sample="{{ resources }}/eccodes_samples/COSMO_GRIB2_default.tmpl"
-  icon_grid_description="/oprusers/osm/opr.emme/data/ICON_INPUT/ICON-CH1-EPS/icon_grid_0001_R19B08_mch.nc"
+  icon_grid_description="{{ icon_grid_description }}"
   rttov_coefs_path="{{ resources }}/rttov_coefficients"
 /
 
 &GlobalSettings
-  default_model_name="icon-ch1-eps"
+  default_model_name="{{ model_name }}"
   default_out_type_stdlongitude=.true.
   location_to_gridpoint="sn"
 /
 
 &ModelSpecification
-  model_name="icon-ch1-eps"
+  model_name="{{ model_name }}"
   earth_axis_large=6371229.
   earth_axis_small=6371229.
   hydrometeor="QR", "QG", "QS"
@@ -35,7 +35,7 @@
 &Process
   in_file  = "{{ file.inputi }}"
   tstart = 0, tstop = 0, tincr = 1
-  out_regrid_target = "rotlatlon,353140000,-4460000,4830000,3390000,10000,10000,190000000,43000000"
+  out_regrid_target = "{{ out_regrid_target }}"
   out_regrid_method = "icontools,rbf"
   out_file = "{{ file.output }}"
   out_type = "NETCDF"

--- a/tests/test_meteodatalab/test_grib_decoder.py
+++ b/tests/test_meteodatalab/test_grib_decoder.py
@@ -56,3 +56,12 @@ def test_save_field(data_dir, tmp_path, param):
     ds_new[param].attrs.pop("message")
 
     xr.testing.assert_identical(ds[param], ds_new[param])
+
+
+@pytest.mark.data("iconremap")
+def test_load_icon(data_dir):
+    datafiles = [str(data_dir / "ICON-CH1-EPS_lfff00000000_000")]
+    source = data_source.DataSource(datafiles=datafiles)
+    ds = grib_decoder.load(source, "U")
+
+    print(ds)

--- a/tests/test_meteodatalab/test_grib_decoder.py
+++ b/tests/test_meteodatalab/test_grib_decoder.py
@@ -56,12 +56,3 @@ def test_save_field(data_dir, tmp_path, param):
     ds_new[param].attrs.pop("message")
 
     xr.testing.assert_identical(ds[param], ds_new[param])
-
-
-@pytest.mark.data("iconremap")
-def test_load_icon(data_dir):
-    datafiles = [str(data_dir / "ICON-CH1-EPS_lfff00000000_000")]
-    source = data_source.DataSource(datafiles=datafiles)
-    ds = grib_decoder.load(source, "U")
-
-    print(ds)

--- a/tests/test_meteodatalab/test_regrid.py
+++ b/tests/test_meteodatalab/test_regrid.py
@@ -64,6 +64,40 @@ def test_to_crs():
 
 @pytest.mark.data("iconremap")
 @pytest.mark.parametrize("model_name", ["icon-ch1-eps", "icon-ch2-eps"])
+def test_icon2geolatlon(data_dir, fieldextra, model_name):
+    datafiles = [str(data_dir / f"{model_name.upper()}_lfff00000000_000")]
+    source = data_source.FileDataSource(datafiles=datafiles)
+    ds = grib_decoder.load(source, "T")
+
+    observed = regrid.icon2geolatlon(ds["T"])
+
+    out_regrid_target = {
+        "icon-ch1-eps": "geolatlon,5500000,43600000,16900000,50000000,10000,10000",
+        "icon-ch2-eps": "geolatlon,5500000,43600000,16900000,50000000,20000,20000",
+    }
+    root = "/oprusers/osm/opr.emme/data/ICON_INPUT"
+    icon_grid_description = {
+        "icon-ch1-eps": f"{root}/ICON-CH1-EPS/icon_grid_0001_R19B08_mch.nc",
+        "icon-ch2-eps": f"{root}/ICON-CH2-EPS/icon_grid_0002_R19B07_mch.nc",
+    }
+
+    fx_ds = fieldextra(
+        "iconremap",
+        model_name=model_name,
+        out_regrid_target=out_regrid_target[model_name],
+        icon_grid_description=icon_grid_description[model_name],
+        conf_files={
+            "inputi": data_dir / f"{model_name.upper()}_lfff<DDHH>0000_000",
+            "output": "<HH>_outfile.nc",
+        },
+    )
+
+    mask = ~observed.isnull().values
+    assert_allclose(observed, fx_ds["T"].where(mask), rtol=1e-4, atol=1e-4)
+
+
+@pytest.mark.data("iconremap")
+@pytest.mark.parametrize("model_name", ["icon-ch1-eps", "icon-ch2-eps"])
 def test_icon2rotlatlon(data_dir, fieldextra, model_name):
     datafiles = [str(data_dir / f"{model_name.upper()}_lfff00000000_000")]
     source = data_source.FileDataSource(datafiles=datafiles)

--- a/tests/test_meteodatalab/test_regrid.py
+++ b/tests/test_meteodatalab/test_regrid.py
@@ -94,4 +94,4 @@ def test_icon2rotlatlon(data_dir, fieldextra, model_name):
         },
     )
 
-    assert_allclose(observed, fx_ds["T"], rtol=1e-3, atol=1e-3)
+    assert_allclose(observed, fx_ds["T"], rtol=1e-4, atol=1e-4)

--- a/tests/test_meteodatalab/test_regrid.py
+++ b/tests/test_meteodatalab/test_regrid.py
@@ -6,7 +6,7 @@ import pytest
 from numpy.testing import assert_allclose
 
 # First-party
-from meteodatalab import grib_decoder, data_source
+from meteodatalab import data_source, grib_decoder
 from meteodatalab.operators import regrid
 from meteodatalab.operators.hzerocl import fhzerocl
 
@@ -66,7 +66,7 @@ def test_to_crs():
 @pytest.mark.parametrize("model_name", ["icon-ch1-eps", "icon-ch2-eps"])
 def test_icon2rotlatlon(data_dir, fieldextra, model_name):
     datafiles = [str(data_dir / f"{model_name.upper()}_lfff00000000_000")]
-    source = data_source.DataSource(datafiles=datafiles)
+    source = data_source.FileDataSource(datafiles=datafiles)
     ds = grib_decoder.load(source, "T")
 
     observed = regrid.icon2rotlatlon(ds["T"])

--- a/tests/test_meteodatalab/test_regrid.py
+++ b/tests/test_meteodatalab/test_regrid.py
@@ -63,17 +63,33 @@ def test_to_crs():
 
 
 @pytest.mark.data("iconremap")
-def test_icon2rotlatlon(data_dir, fieldextra):
-    datafiles = [str(data_dir / "ICON-CH1-EPS_lfff00000000_000")]
+@pytest.mark.parametrize("model_name", ["icon-ch1-eps", "icon-ch2-eps"])
+def test_icon2rotlatlon(data_dir, fieldextra, model_name):
+    datafiles = [str(data_dir / f"{model_name.upper()}_lfff00000000_000")]
     source = data_source.DataSource(datafiles=datafiles)
     ds = grib_decoder.load(source, "T")
 
     observed = regrid.icon2rotlatlon(ds["T"])
 
+    out_regrid_target = {
+        "icon-ch1-eps": "rotlatlon,353140000,-4460000,4830000,3390000,10000,10000,"
+        "190000000,43000000",
+        "icon-ch2-eps": "rotlatlon,353180000,-4420000,4800000,3360000,20000,20000,"
+        "190000000,43000000",
+    }
+    root = "/oprusers/osm/opr.emme/data/ICON_INPUT"
+    icon_grid_description = {
+        "icon-ch1-eps": f"{root}/ICON-CH1-EPS/icon_grid_0001_R19B08_mch.nc",
+        "icon-ch2-eps": f"{root}/ICON-CH2-EPS/icon_grid_0002_R19B07_mch.nc",
+    }
+
     fx_ds = fieldextra(
         "iconremap",
+        model_name=model_name,
+        out_regrid_target=out_regrid_target[model_name],
+        icon_grid_description=icon_grid_description[model_name],
         conf_files={
-            "inputi": data_dir / "ICON-CH1-EPS_lfff<DDHH>0000_000",
+            "inputi": data_dir / f"{model_name.upper()}_lfff<DDHH>0000_000",
             "output": "<HH>_outfile.nc",
         },
     )


### PR DESCRIPTION
## Purpose

Provide the ability to remap data from ICON native grid to regular latlon grid.

- [x] implement geolatlon
- [ ] implement nnb?

## Code changes:

- `grib_decoder.load` is able to read GRIB containing data in the ICON native grid
- added `regrid.icon2rotlatlon` function

## Infrastructure changes:

- [x] add jenkinsfile to manage the building and generation of weights by icontools

