### PR TITLE
Data source url

### DIFF
--- a/src/meteodatalab/data_source.py
+++ b/src/meteodatalab/data_source.py
@@ -150,5 +150,5 @@ class URLDataSource(DataSource):
 
     def _retrieve(self, request: dict):
         req_kwargs = self.request_template | request
-        fs = ekd.from_source("url", self.urls, stream=True)
+        fs = ekd.from_source("url", self.urls)
         yield from fs.sel(**req_kwargs)

--- a/src/meteodatalab/grib_decoder.py
+++ b/src/meteodatalab/grib_decoder.py
@@ -276,7 +276,7 @@ class GribReader:
             if the grid can not be constructed from the ref_param
 
         """
-        return cls(data_source.DataSource([str(p) for p in datafiles]), ref_param)
+        return cls(data_source.FileDataSource([str(p) for p in datafiles]), ref_param)
 
     def load(
         self,

--- a/src/meteodatalab/grib_decoder.py
+++ b/src/meteodatalab/grib_decoder.py
@@ -276,7 +276,9 @@ class GribReader:
             if the grid can not be constructed from the ref_param
 
         """
-        return cls(data_source.FileDataSource([str(p) for p in datafiles]), ref_param)
+        return cls(
+            data_source.FileDataSource(datafiles=[str(p) for p in datafiles]), ref_param
+        )
 
     def load(
         self,

--- a/src/meteodatalab/mch_model_data.py
+++ b/src/meteodatalab/mch_model_data.py
@@ -53,7 +53,7 @@ def get_from_fdb(request: mars.Request) -> dict[str, xr.DataArray]:
         logger.exception(msg)
         raise ValueError(msg)
     logger.info("Getting request %s from FDB.", request)
-    source = data_source.DataSource()
+    source = data_source.FDBDataSource()
     return grib_decoder.load(source, request)
 
 
@@ -85,13 +85,13 @@ def get_from_polytope(request: mars.Request) -> dict[str, xr.DataArray]:
         logger.exception(msg)
         raise RuntimeError(msg)
     if request.feature is not None:
-        source = data_source.DataSource(polytope_collection="mchgj")
+        source = data_source.PolytopeDataSource(polytope_collection="mchgj")
         [result] = source.retrieve(request)
         return result.to_xarray()
     else:
         collection = "mch"
     logger.info("Getting request %s from polytope collection %s", request, collection)
-    source = data_source.DataSource(polytope_collection=collection)
+    source = data_source.PolytopeDataSource(polytope_collection=collection)
     return grib_decoder.load(source, request)
 
 

--- a/tests/test_meteodatalab/test_brn.py
+++ b/tests/test_meteodatalab/test_brn.py
@@ -3,7 +3,7 @@ from numpy.testing import assert_allclose
 
 # First-party
 import meteodatalab.operators.brn as mbrn
-from meteodatalab.data_source import DataSource
+from meteodatalab.data_source import FileDataSource
 from meteodatalab.grib_decoder import load
 from meteodatalab.metadata import set_origin_xy
 
@@ -12,7 +12,7 @@ def test_brn(data_dir, fieldextra):
     datafile = data_dir / "COSMO-1E/1h/ml_sl/000/lfff00000000"
     cdatafile = data_dir / "COSMO-1E/1h/const/000/lfff00000000c"
 
-    source = DataSource(datafiles=[datafile, cdatafile])
+    source = FileDataSource(datafiles=[datafile, cdatafile])
     ds = load(source, {"param": ["P", "T", "QV", "U", "V", "HHL", "HSURF"]})
     set_origin_xy(ds, "HHL")
 

--- a/tests/test_meteodatalab/test_curl.py
+++ b/tests/test_meteodatalab/test_curl.py
@@ -3,7 +3,7 @@ import numpy as np
 from xarray.testing import assert_allclose
 
 # First-party
-from meteodatalab.data_source import DataSource
+from meteodatalab.data_source import FileDataSource
 from meteodatalab.grib_decoder import load
 from meteodatalab.metadata import set_origin_xy
 from meteodatalab.operators import curl
@@ -15,7 +15,7 @@ def test_curl(data_dir):
     datafile = data_dir / "COSMO-1E/1h/ml_sl/000/lfff00000000"
     cdatafile = data_dir / "COSMO-1E/1h/const/000/lfff00000000c"
 
-    source = DataSource(datafiles=[cdatafile, datafile])
+    source = FileDataSource(datafiles=[cdatafile, datafile])
     ds = load(source, {"param": ["U", "V", "W", "HHL"]})
     set_origin_xy(ds, ref_param="HHL")
 

--- a/tests/test_meteodatalab/test_data_source.py
+++ b/tests/test_meteodatalab/test_data_source.py
@@ -26,7 +26,7 @@ def test_retrieve_files(mock_from_source, mock_grib_def_ctx):
     datafiles = ["foo"]
     param = "bar"
 
-    source = data_source.DataSource(datafiles)
+    source = data_source.FileDataSource(datafiles)
     for _ in source.retrieve(param):
         pass
 
@@ -42,7 +42,7 @@ def test_retrieve_files_tuple(mock_from_source, mock_grib_def_ctx):
     datafiles = ["foo"]
     request = param, levtype = ("bar", "ml")
 
-    source = data_source.DataSource(datafiles)
+    source = data_source.FileDataSource(datafiles)
     for _ in source.retrieve(request):
         pass
 
@@ -59,7 +59,7 @@ def test_retrieve_files_ifs(mock_from_source, mock_grib_def_ctx):
     param = "bar"
 
     with config.set_values(data_scope="ifs"):
-        source = data_source.DataSource(datafiles)
+        source = data_source.FileDataSource(datafiles)
         for _ in source.retrieve(param):
             pass
 
@@ -75,7 +75,7 @@ def test_retrieve_fdb(mock_from_source, mock_grib_def_ctx):
     param = "U"
     template = {"date": "20200101", "time": "0000"}
 
-    source = data_source.DataSource(request_template=template)
+    source = data_source.FileDataSource(request_template=template)
     for _ in source.retrieve(param):
         pass
 
@@ -91,7 +91,7 @@ def test_retrieve_fdb_mars(mock_from_source, mock_grib_def_ctx):
     request = mars.Request(param=param)
     template = {"date": "20200101", "time": "0000"}
 
-    source = data_source.DataSource(request_template=template)
+    source = data_source.FileDataSource(request_template=template)
     for _ in source.retrieve(request):
         pass
 

--- a/tests/test_meteodatalab/test_data_source.py
+++ b/tests/test_meteodatalab/test_data_source.py
@@ -26,7 +26,7 @@ def test_retrieve_files(mock_from_source, mock_grib_def_ctx):
     datafiles = ["foo"]
     param = "bar"
 
-    source = data_source.FileDataSource(datafiles)
+    source = data_source.FileDataSource(datafiles=datafiles)
     for _ in source.retrieve(param):
         pass
 
@@ -42,7 +42,7 @@ def test_retrieve_files_tuple(mock_from_source, mock_grib_def_ctx):
     datafiles = ["foo"]
     request = param, levtype = ("bar", "ml")
 
-    source = data_source.FileDataSource(datafiles)
+    source = data_source.FileDataSource(datafiles=datafiles)
     for _ in source.retrieve(request):
         pass
 
@@ -59,7 +59,7 @@ def test_retrieve_files_ifs(mock_from_source, mock_grib_def_ctx):
     param = "bar"
 
     with config.set_values(data_scope="ifs"):
-        source = data_source.FileDataSource(datafiles)
+        source = data_source.FileDataSource(datafiles=datafiles)
         for _ in source.retrieve(param):
             pass
 
@@ -75,7 +75,7 @@ def test_retrieve_fdb(mock_from_source, mock_grib_def_ctx):
     param = "U"
     template = {"date": "20200101", "time": "0000"}
 
-    source = data_source.FileDataSource(request_template=template)
+    source = data_source.FDBDataSource(request_template=template)
     for _ in source.retrieve(param):
         pass
 
@@ -91,7 +91,7 @@ def test_retrieve_fdb_mars(mock_from_source, mock_grib_def_ctx):
     request = mars.Request(param=param)
     template = {"date": "20200101", "time": "0000"}
 
-    source = data_source.FileDataSource(request_template=template)
+    source = data_source.FDBDataSource(request_template=template)
     for _ in source.retrieve(request):
         pass
 

--- a/tests/test_meteodatalab/test_grib_decoder.py
+++ b/tests/test_meteodatalab/test_grib_decoder.py
@@ -10,7 +10,7 @@ from meteodatalab import data_source, grib_decoder
     "params,levtype", [(["P", "T", "HHL"], "ml"), (["U_10M", "V_10M"], "sfc")]
 )
 def test_load(params, levtype, request_template, setup_fdb):
-    source = data_source.DataSource()
+    source = data_source.FDBDataSource()
     request = request_template | {"param": params, "levtype": levtype}
     ds = grib_decoder.load(source, request)
     assert ds.keys() == set(params)

--- a/tests/test_meteodatalab/test_metadata.py
+++ b/tests/test_meteodatalab/test_metadata.py
@@ -16,7 +16,7 @@ from meteodatalab import data_source, grib_decoder, metadata
 def test_extract_keys(data_dir, keys, values):
     cdatafile = data_dir / "COSMO-1E/1h/const/000/lfff00000000c"
 
-    source = data_source.DataSource([str(cdatafile)])
+    source = data_source.FileDataSource([str(cdatafile)])
     ds = grib_decoder.load(source, {"param": ["HHL"]})
 
     observed = metadata.extract_keys(ds["HHL"].message, keys)
@@ -28,7 +28,7 @@ def test_extract_keys(data_dir, keys, values):
 def test_extract_keys_raises(data_dir):
     cdatafile = data_dir / "COSMO-1E/1h/const/000/lfff00000000c"
 
-    source = data_source.DataSource([str(cdatafile)])
+    source = data_source.FileDataSource([str(cdatafile)])
     ds = grib_decoder.load(source, {"param": ["HHL"]})
 
     with pytest.raises(ValueError):

--- a/tests/test_meteodatalab/test_metadata.py
+++ b/tests/test_meteodatalab/test_metadata.py
@@ -16,7 +16,7 @@ from meteodatalab import data_source, grib_decoder, metadata
 def test_extract_keys(data_dir, keys, values):
     cdatafile = data_dir / "COSMO-1E/1h/const/000/lfff00000000c"
 
-    source = data_source.FileDataSource([str(cdatafile)])
+    source = data_source.FileDataSource(datafiles=[str(cdatafile)])
     ds = grib_decoder.load(source, {"param": ["HHL"]})
 
     observed = metadata.extract_keys(ds["HHL"].message, keys)
@@ -28,7 +28,7 @@ def test_extract_keys(data_dir, keys, values):
 def test_extract_keys_raises(data_dir):
     cdatafile = data_dir / "COSMO-1E/1h/const/000/lfff00000000c"
 
-    source = data_source.FileDataSource([str(cdatafile)])
+    source = data_source.FileDataSource(datafiles=[str(cdatafile)])
     ds = grib_decoder.load(source, {"param": ["HHL"]})
 
     with pytest.raises(ValueError):

--- a/tests/test_meteodatalab/test_potvortic.py
+++ b/tests/test_meteodatalab/test_potvortic.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_allclose
 # First-party
 import meteodatalab.operators.pot_vortic as pv
 from meteodatalab.data_cache import DataCache
-from meteodatalab.data_source import DataSource
+from meteodatalab.data_source import FDBDataSource
 from meteodatalab.grib_decoder import load
 from meteodatalab.metadata import set_origin_xy
 from meteodatalab.operators.rho import compute_rho_tot
@@ -14,7 +14,7 @@ from meteodatalab.operators.theta import compute_theta
 
 @pytest.fixture
 def data(work_dir, request_template, setup_fdb):
-    source = DataSource(request_template=request_template)
+    source = FDBDataSource(request_template=request_template)
     fields = {
         "inputi": [(p, "ml") for p in ("U", "V", "W", "P", "T", "QV", "QC", "QI")],
         "inputc": [("HHL", "ml"), ("HSURF", "sfc"), ("FIS", "sfc")],

--- a/tests/test_meteodatalab/test_product.py
+++ b/tests/test_meteodatalab/test_product.py
@@ -54,7 +54,7 @@ def test_merge(mock_reader_cls):
     mock_reader_cls.return_value = m.reader
     m.reader.load.side_effect = load
 
-    source = data_source.DataSource()
+    source = data_source.FDBDataSource()
     product.run_products([product_a, product_b], source)
 
     # requests have been merged
@@ -83,6 +83,6 @@ class ProductC(product.Product):
 
 def test_raises_on_conflict():
     m = mock.Mock()
-    source = data_source.DataSource()
+    source = data_source.FDBDataSource()
     with pytest.raises(RuntimeError):
         product.run_products([ProductA(m.a), ProductB(m.b), ProductC(m.c)], source)

--- a/tests/test_meteodatalab/test_wind.py
+++ b/tests/test_meteodatalab/test_wind.py
@@ -4,7 +4,7 @@ from numpy.testing import assert_allclose
 
 # First-party
 from meteodatalab.data_cache import DataCache
-from meteodatalab.data_source import DataSource
+from meteodatalab.data_source import FDBDataSource
 from meteodatalab.grib_decoder import GribReader
 from meteodatalab.metadata import set_origin_xy
 from meteodatalab.operators import wind
@@ -12,7 +12,7 @@ from meteodatalab.operators import wind
 
 @pytest.fixture
 def data(work_dir, request_template, setup_fdb):
-    source = DataSource(request_template=request_template)
+    source = FDBDataSource(request_template=request_template)
     fields = {
         "inputi": [(p, "sfc") for p in ("U_10M", "V_10M")],
     }


### PR DESCRIPTION
## Purpose

Split the functionality into child classes to make it more explicit where the data is sourced from at the call site. Added the functionality to source data from a URL directly. Note that the data is cached in a temporary file as controlled by the earthkit data cache policy setting. This is becase stream source does not implement the `sel` method at this time.
https://earthkit-data.readthedocs.io/en/latest/guide/caching.html#cache-policies

## Code changes:

- `data_source.DataSource` is now an abstract base class
- Refactored `FDBDataSource`, `FileDataSource`, `PolytopeDataSource` that inherit from `DataSource`
- Added `URLDataSource`