### PR TITLE
fix: save to grib for lead time and time range

### DIFF
--- a/src/meteodatalab/grib_decoder.py
+++ b/src/meteodatalab/grib_decoder.py
@@ -402,6 +402,9 @@ def save(
     time_range_unit = UnitOfTime(md.get("indicatorOfUnitForTimeRange", 255)).unit
     time_range = _to_timedelta(md.get("lengthOfTimeRange", 0), unit=time_range_unit)
 
+    if md.get("numberOfTimeRange", 1) != 1:
+        raise NotImplementedError("Unsupported value for numberOfTimeRange")
+
     def to_grib(loc: dict[str, xr.DataArray]):
         grib_loc = {
             DIM_MAP[key]: value.item()

--- a/src/meteodatalab/grib_decoder.py
+++ b/src/meteodatalab/grib_decoder.py
@@ -8,6 +8,7 @@ import logging
 import typing
 from collections import UserDict
 from collections.abc import Mapping, Sequence
+from enum import Enum
 from itertools import product
 from pathlib import Path
 from warnings import warn
@@ -59,6 +60,20 @@ class MissingData(RuntimeError):
     pass
 
 
+class UnitOfTime(Enum):
+    MINUTE = 0
+    HOUR = 1
+    DAY = 2
+    SECOND = 13
+    MISSING = 255
+
+    @property
+    def unit(self):
+        if self.name == "MISSING":
+            return None
+        return self.name.lower()
+
+
 def _is_ensemble(field) -> bool:
     try:
         return field.metadata("typeOfEnsembleForecast") == 192
@@ -66,8 +81,12 @@ def _is_ensemble(field) -> bool:
         return False
 
 
-def _parse_datetime(date, time):
+def _parse_datetime(date, time) -> dt.datetime:
     return dt.datetime.strptime(f"{date}{time:04d}", "%Y%m%d%H%M")
+
+
+def _to_timedelta(value, unit) -> np.timedelta64:
+    return pd.to_timedelta(value, unit).to_numpy()
 
 
 def _get_key(field, dims):
@@ -76,7 +95,7 @@ def _get_key(field, dims):
     unit = "h" if isinstance(step, int) else None
     extra = {
         "ref_time": _parse_datetime(md["dataDate"], md["dataTime"]),
-        "step": pd.to_timedelta(step, unit),
+        "step": _to_timedelta(step, unit),
     }
     dim_keys = (DIM_MAP[dim] for dim in dims)
     mapping = ChainMap(extra, md)
@@ -379,13 +398,21 @@ def save(
         if (dim := str(key)) not in {"x", "y"}
     }
 
+    step_unit = UnitOfTime.MINUTE
+    time_range_unit = UnitOfTime(md.get("indicatorOfUnitForTimeRange", 255)).unit
+    time_range = _to_timedelta(md.get("lengthOfTimeRange", 0), unit=time_range_unit)
+
     def to_grib(loc: dict[str, xr.DataArray]):
         grib_loc = {
             DIM_MAP[key]: value.item()
             for key, value in loc.items()
-            if key != "ref_time"
+            if key not in {"ref_time", "lead_time"}
         }
+        step_end = np.timedelta64(loc["lead_time"].item(), "ns")
+        step_begin = step_end - time_range
         return grib_loc | {
+            "indicatorOfUnitOfTimeRange": step_unit.value,
+            "forecastTime": step_begin / _to_timedelta(1, step_unit.unit),
             "dataDate": loc["ref_time"].dt.strftime("%Y%m%d").item(),
             "dataTime": loc["ref_time"].dt.strftime("%H%M").item(),
         }

--- a/tests/test_meteodatalab/test_grib_decoder.py
+++ b/tests/test_meteodatalab/test_grib_decoder.py
@@ -39,7 +39,7 @@ def test_save(data_dir, tmp_path):
 
 @pytest.mark.parametrize("param", ("U", "V", "T"))
 def test_save_field(data_dir, tmp_path, param):
-    datafile = data_dir / "COSMO-1E/1h/ml_sl/000/lfff00000000"
+    datafile = data_dir / "COSMO-1E/1h/ml_sl/000/lfff00010000"
     cdatafile = data_dir / "COSMO-1E/1h/const/000/lfff00000000c"
 
     reader = grib_decoder.GribReader.from_files([datafile, cdatafile])

--- a/tests/test_meteodatalab/test_time_ops.py
+++ b/tests/test_meteodatalab/test_time_ops.py
@@ -18,7 +18,7 @@ from meteodatalab.operators import radiation
 def _assert_keys(field, mapping):
     handle = io.BytesIO()
     save(field, handle)
-    observed = extract_keys(handle.getvalue(), list(mapping.keys()), multiple=True)
+    observed = extract_keys(handle.getvalue(), list(mapping.keys()), single=False)
     expected = list(mapping.values())
     for values in observed:
         assert values == expected

--- a/tests/test_meteodatalab/test_time_ops.py
+++ b/tests/test_meteodatalab/test_time_ops.py
@@ -1,3 +1,6 @@
+# Standard library
+import io
+
 # Third-party
 import numpy as np
 import pandas as pd  # type: ignore
@@ -7,9 +10,18 @@ from numpy.testing import assert_allclose
 
 # First-party
 import meteodatalab.operators.time_operators as time_ops
-from meteodatalab.grib_decoder import GribReader
+from meteodatalab.grib_decoder import GribReader, save
 from meteodatalab.metadata import extract_keys
 from meteodatalab.operators import radiation
+
+
+def _assert_keys(field, mapping):
+    handle = io.BytesIO()
+    save(field, handle)
+    observed = extract_keys(handle.getvalue(), list(mapping.keys()), multiple=True)
+    expected = list(mapping.values())
+    for values in observed:
+        assert values == expected
 
 
 @pytest.mark.data("reduced-time")
@@ -22,21 +34,7 @@ def test_delta(data_dir, fieldextra):
     ds = reader.load_fieldnames(["TOT_PREC"])
 
     tot_prec = time_ops.resample(ds["TOT_PREC"], np.timedelta64(3, "h"))
-
-    observed_tr = extract_keys(tot_prec.message, "lengthOfTimeRange")
-    expected_tr = int(np.timedelta64(3, "h") / np.timedelta64(1, "m"))
-
-    assert observed_tr == expected_tr
-    assert extract_keys(tot_prec.message, "indicatorOfUnitForTimeRange") == 0
-
     tot_prec_03h = time_ops.delta(tot_prec, np.timedelta64(3, "h"))
-
-    assert extract_keys(tot_prec_03h.message, "typeOfStatisticalProcessing") == 4
-    assert extract_keys(tot_prec_03h.message, "indicatorOfUnitForTimeRange") == 0
-    observed_tr = extract_keys(tot_prec_03h.message, "lengthOfTimeRange")
-    expected_tr = int(np.timedelta64(3, "h") / np.timedelta64(1, "m"))
-
-    assert observed_tr == expected_tr
 
     # Negative values are replaced by zero as these are due to numerical inaccuracies.
     cond = np.logical_or(tot_prec_03h > 0.0, tot_prec_03h.isnull())
@@ -58,6 +56,13 @@ def test_delta(data_dir, fieldextra):
 
     assert_allclose(observed, expected)
 
+    md = {
+        "typeOfStatisticalProcessing": 4,
+        "indicatorOfUnitForTimeRange": 0,
+        "lengthOfTimeRange": 3 * 60,
+    }
+    _assert_keys(observed, md)
+
 
 @pytest.mark.data("reduced-time")
 def test_resample_average(data_dir, fieldextra):
@@ -70,13 +75,6 @@ def test_resample_average(data_dir, fieldextra):
 
     direct = time_ops.resample_average(ds["ASWDIR_S"], np.timedelta64(1, "h"))
     diffuse = time_ops.resample_average(ds["ASWDIFD_S"], np.timedelta64(1, "h"))
-
-    observed_tr = extract_keys(diffuse.message, "lengthOfTimeRange")
-    expected_tr = int(np.timedelta64(1, "h") / np.timedelta64(1, "m"))
-
-    assert observed_tr == expected_tr
-    assert extract_keys(diffuse.message, "typeOfStatisticalProcessing") == 0
-    assert extract_keys(diffuse.message, "indicatorOfUnitForTimeRange") == 0
 
     observed = radiation.compute_swdown(diffuse, direct)
 
@@ -108,6 +106,13 @@ def test_resample_average(data_dir, fieldextra):
         rtol=1e-5,
         atol=1e-5,
     )
+
+    md = {
+        "typeOfStatisticalProcessing": 0,
+        "indicatorOfUnitForTimeRange": 0,
+        "lengthOfTimeRange": 60,
+    }
+    _assert_keys(observed, md)
 
 
 @pytest.mark.data("reduced-time")


### PR DESCRIPTION
## Purpose

Setting the time coordinate through the `step` overrides the `lengthOfTimeRange` that may have been set by an operator.

## Code changes:

- `grib_decoder.save` takes into account the value of `lengthOfTimeRange` to determine the `forecastTime` value
- fixed: setting step in minutes rather than nanoseconds

