### PR TITLE
fix pressure level metadata

### DIFF
--- a/src/meteodatalab/operators/vertical_interpolation.py
+++ b/src/meteodatalab/operators/vertical_interpolation.py
@@ -82,9 +82,9 @@ def interpolate_k2p(
         )
     tc = TargetCoordinates(
         type_of_level="isobaricInPa",
-        values=tc_values.tolist(),
+        values=[val * 1e-2 for val in tc_values.tolist()],
         attrs=TargetCoordinatesAttrs(
-            units="Pa",
+            units="hPa",
             positive="down",
             standard_name="air_pressure",
             long_name="pressure",


### PR DESCRIPTION
## Purpose

When using interpolate_k2p with 50 hPa as parameters, the output written in grib comes with wrong metadata (by factor 100)
23        typeOfFirstFixedSurface = 100 [Isobaric surface (Pa)  (grib2/tables/11/4.5.table) ]
24        scaleFactorOfFirstFixedSurface = 0
25-28     scaledValueOfFirstFixedSurface = 500000

The problem is, I think, that the derived key "level" is interpreted as hPa

## Code changes:

- Modify the coordinates so that 'z' is represented in hPa

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://meteoswiss.atlassian.net/wiki/spaces/UA/pages/20157433/Factory).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README)
- [x] Unit tests are added or updated for non-operator code
- [x] New operators are properly tested

Additionally, if the PR updates the version of the package

- [ ] The new version is properly set
- [ ] A Tag will be created after the bump

## Review
For the review process follow the guidelines at [Checklist](https://meteoswiss.atlassian.net/wiki/spaces/UA/pages/20156488/Code+Review)
