### PR TITLE
fix: avoid mutating input field attrs in regrid

### DIFF
--- a/src/meteodatalab/operators/regrid.py
+++ b/src/meteodatalab/operators/regrid.py
@@ -306,7 +306,7 @@ def regrid(
 
     attrs = field.attrs
     if md := _get_metadata(dst):
-        attrs |= metadata.override(field.message, **md)
+        attrs = attrs | metadata.override(field.message, **md)
 
     return xr.DataArray(data, attrs=attrs)
 
@@ -336,7 +336,7 @@ def _icon2regular(
 
     attrs = field.attrs
     if md := _get_metadata(dst):
-        attrs |= metadata.override(field.message, **md)
+        attrs = attrs | metadata.override(field.message, **md)
 
     return xr.DataArray(data, attrs=attrs)
 

--- a/tests/test_meteodatalab/test_regrid.py
+++ b/tests/test_meteodatalab/test_regrid.py
@@ -68,8 +68,11 @@ def test_icon2geolatlon(data_dir, fieldextra, model_name):
     datafiles = [str(data_dir / f"{model_name.upper()}_lfff00000000_000")]
     source = data_source.FileDataSource(datafiles=datafiles)
     ds = grib_decoder.load(source, "T")
+    original = ds["T"].attrs.copy()
 
     observed = regrid.icon2geolatlon(ds["T"])
+
+    assert ds["T"].attrs == original
 
     out_regrid_target = {
         "icon-ch1-eps": "geolatlon,5500000,43600000,16900000,50000000,10000,10000",


### PR DESCRIPTION
- avoid mutating the `attrs` dict of the input field when preparing the `attrs` of the output field in the regrid operators. 