### PR TITLE
Update GRIB2 encoding for `omega_slope` operator to use `etadot` code for Flexpart compatibility

### DIFF
--- a/src/meteodatalab/operators/omega_slope.py
+++ b/src/meteodatalab/operators/omega_slope.py
@@ -71,10 +71,10 @@ def omega_slope(
     return xr.DataArray(
         data=res,
         attrs=metadata.override(
-            # Vertical velocity (pressure)
+            # Eta-coordinate vertical velocity
             etadot.message,
             discipline=0,
             parameterCategory=2,
-            parameterNumber=8,
+            parameterNumber=32,
         ),
     )

--- a/tests/test_meteodatalab/test_flexpart.py
+++ b/tests/test_meteodatalab/test_flexpart.py
@@ -95,10 +95,10 @@ def test_flexpart(data_dir, fieldextra):
 
     assert ds_out["omega"].parameter == {
         "centre": "ecmf",
-        "paramId": 135,
-        "shortName": "w",
-        "units": "Pa s**-1",
-        "name": "Vertical velocity",
+        "paramId": 77,
+        "shortName": "etadot",
+        "units": "s**-1",
+        "name": "Eta-coordinate vertical velocity",
     }
 
     assert_allclose(fs_ds_o["ETADOT"], ds_out["omega"], rtol=3e-6, atol=5e-5)


### PR DESCRIPTION
## Purpose

Adjust the GRIB2 message for the parameter output by the `omega_slope` operator (used exclusively for Flexpart). Flexpart requires the vertical velocity in units of [Pa/s] (`omega`), but with the GRIB2 code assigned to `etadot` rather than the GRIB2 code for `omega`.