### PR TITLE
check for eccodes definitions env var

### DIFF
--- a/src/meteodatalab/data_source.py
+++ b/src/meteodatalab/data_source.py
@@ -4,6 +4,7 @@
 import dataclasses as dc
 import sys
 import typing
+import os
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from contextlib import contextmanager, nullcontext
@@ -22,6 +23,9 @@ from . import config, mars
 @contextmanager
 def cosmo_grib_defs():
     """Enable COSMO GRIB definitions."""
+    if "ECCODES_DEFINITION_PATH" in os.environ or "GRIB_DEFINITION_PATH" in os.environ:
+        return nullcontext()
+
     restore = eccodes.codes_definition_path()
     root_dir = Path(sys.prefix) / "share"
     paths = (

--- a/src/meteodatalab/data_source.py
+++ b/src/meteodatalab/data_source.py
@@ -2,9 +2,9 @@
 
 # Standard library
 import dataclasses as dc
+import os
 import sys
 import typing
-import os
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from contextlib import contextmanager, nullcontext


### PR DESCRIPTION
## Purpose

Do not attempt to include DWD / COSMO definitions if the environment variable is set. This allows the user to override the definitions if needed.

Closes #49 
