### PR TITLE
Fix barycentric interpolation

### DIFF
--- a/src/meteodatalab/operators/regrid.py
+++ b/src/meteodatalab/operators/regrid.py
@@ -500,7 +500,7 @@ def iconremap(
     indices, weights = _linear_weights_cropped_domain(xy, uv)
 
     transformer_geo = Transformer.from_crs(dst.crs.wkt, "epsg:4326", always_xy=True)
-    lon, lat = transformer_geo.transform(gx, gy).T
+    lon, lat = transformer_geo.transform(gx, gy)
 
     return _icon2regular(field, dst, indices, weights).assign_coords(
         lon=(("y", "x"), lon), lat=(("y", "x"), lat)

--- a/src/meteodatalab/operators/regrid.py
+++ b/src/meteodatalab/operators/regrid.py
@@ -440,13 +440,19 @@ def _linear_weights(pts_src: ArrayLike, pts_dst: ArrayLike) -> tuple[NDArray, ND
 def _linear_weights_cropped_domain(
     pts_src: ArrayLike, pts_dst: ArrayLike, buffer: float = 4e3
 ) -> tuple[NDArray, NDArray]:
-    """Crop the grid to output domain."""
+    """Computes the linear interpolation weights from pts_src to pts_dst
+
+    Both pts_src and pts_dst are expected to be rank 2 arrays representing a list of points
+    using the same coordinate system. The source grid is first cropped to the domain with a
+    buffer outside of the destination. The default buffer provides a 4 km buffer when using
+    a meter-based coordinate system.
+    """
     xmin, ymin = np.min(pts_dst, axis=0) - buffer
     xmax, ymax = np.max(pts_dst, axis=0) + buffer
     x, y = np.transpose(pts_src)
     mask = (xmin < x) & (x < xmax) & (ymin < y) & (y < ymax)
     [idx] = np.nonzero(mask)
-    indices, weights = _linear_weights(np.extract(mask, pts_src), pts_dst)
+    indices, weights = _linear_weights(pts_src[mask], pts_dst)
     return idx[indices], weights
 
 
@@ -480,11 +486,11 @@ def iconremap(
 
     utm_crs = "epsg:32632"  # UTM zone 32N
 
-    transformer_src = Transformer.from_crs("epsg:4326", utm_crs)
-    points_src = transformer_src.transform(field.lat, field.lon)
+    transformer_src = Transformer.from_crs("epsg:4326", utm_crs, always_xy=True)
+    points_src = transformer_src.transform(field.lon, field.lat)
 
     gx, gy = np.meshgrid(dst.x, dst.y)
-    transformer_dst = Transformer.from_crs(dst.crs.wkt, utm_crs)
+    transformer_dst = Transformer.from_crs(dst.crs.wkt, utm_crs, always_xy=True)
     points_dst = transformer_dst.transform(gx.flat, gy.flat)
 
     xy = np.array(points_src).T
@@ -492,4 +498,8 @@ def iconremap(
 
     indices, weights = _linear_weights_cropped_domain(xy, uv)
 
-    return _icon2regular(field, dst, indices, weights)
+    transformer_geoll = Transformer.from_crs(dst.crs.wkt, "epsg:4326", always_xy=True) 
+    points_ll = transformer_geoll.transform(gx, gy)
+
+    return _icon2regular(field, dst, indices, weights).assign_coords(
+        lon=(("y", "x"), points_ll[0]), lat=(("y", "x"), points_ll[1]))

--- a/src/meteodatalab/operators/regrid.py
+++ b/src/meteodatalab/operators/regrid.py
@@ -498,8 +498,9 @@ def iconremap(
 
     indices, weights = _linear_weights_cropped_domain(xy, uv)
 
-    transformer_geoll = Transformer.from_crs(dst.crs.wkt, "epsg:4326", always_xy=True) 
+    transformer_geoll = Transformer.from_crs(dst.crs.wkt, "epsg:4326", always_xy=True)
     points_ll = transformer_geoll.transform(gx, gy)
 
     return _icon2regular(field, dst, indices, weights).assign_coords(
-        lon=(("y", "x"), points_ll[0]), lat=(("y", "x"), points_ll[1]))
+        lon=(("y", "x"), points_ll[0]), lat=(("y", "x"), points_ll[1])
+    )

--- a/src/meteodatalab/operators/regrid.py
+++ b/src/meteodatalab/operators/regrid.py
@@ -438,7 +438,7 @@ def _linear_weights(pts_src: ArrayLike, pts_dst: ArrayLike) -> tuple[NDArray, ND
 
 
 def _linear_weights_cropped_domain(
-    pts_src: ArrayLike, pts_dst: ArrayLike, buffer: float = 4e3
+    pts_src: NDArray, pts_dst: NDArray, buffer: float = 4e3
 ) -> tuple[NDArray, NDArray]:
     """Compute linear interpolation weights from a cropped source grid.
 
@@ -453,7 +453,7 @@ def _linear_weights_cropped_domain(
     x, y = np.transpose(pts_src)
     mask = (xmin < x) & (x < xmax) & (ymin < y) & (y < ymax)
     [idx] = np.nonzero(mask)
-    indices, weights = _linear_weights(pts_src[mask], pts_dst)
+    indices, weights = _linear_weights(pts_src[idx], pts_dst)
     return idx[indices], weights
 
 

--- a/src/meteodatalab/operators/regrid.py
+++ b/src/meteodatalab/operators/regrid.py
@@ -499,9 +499,9 @@ def iconremap(
 
     indices, weights = _linear_weights_cropped_domain(xy, uv)
 
-    transformer_geoll = Transformer.from_crs(dst.crs.wkt, "epsg:4326", always_xy=True)
-    points_ll = transformer_geoll.transform(gx, gy)
+    transformer_geo = Transformer.from_crs(dst.crs.wkt, "epsg:4326", always_xy=True)
+    lon, lat = transformer_geo.transform(gx, gy).T
 
     return _icon2regular(field, dst, indices, weights).assign_coords(
-        lon=(("y", "x"), points_ll[0]), lat=(("y", "x"), points_ll[1])
+        lon=(("y", "x"), lon), lat=(("y", "x"), lat)
     )

--- a/src/meteodatalab/operators/regrid.py
+++ b/src/meteodatalab/operators/regrid.py
@@ -440,12 +440,13 @@ def _linear_weights(pts_src: ArrayLike, pts_dst: ArrayLike) -> tuple[NDArray, ND
 def _linear_weights_cropped_domain(
     pts_src: ArrayLike, pts_dst: ArrayLike, buffer: float = 4e3
 ) -> tuple[NDArray, NDArray]:
-    """Computes the linear interpolation weights from pts_src to pts_dst
+    """Compute linear interpolation weights from a cropped source grid.
 
-    Both pts_src and pts_dst are expected to be rank 2 arrays representing a list of points
-    using the same coordinate system. The source grid is first cropped to the domain with a
-    buffer outside of the destination. The default buffer provides a 4 km buffer when using
-    a meter-based coordinate system.
+    Crops the source grid to a box with a buffer outside of the destination grid. The
+    default buffer is 4 km when using a meter-based coordinate system.
+
+    Both pts_src and pts_dst are expected to be rank 2 arrays representing a list of
+    points using the same coordinate system.
     """
     xmin, ymin = np.min(pts_dst, axis=0) - buffer
     xmax, ymax = np.max(pts_dst, axis=0) + buffer

--- a/tests/test_meteodatalab/test_regrid.py
+++ b/tests/test_meteodatalab/test_regrid.py
@@ -144,8 +144,8 @@ def test_icon2swiss_small(data_dir, fieldextra, model_name):
     source = data_source.FileDataSource(datafiles=datafiles)
     ds = grib_decoder.load(source, "T")
 
-    # Use a small area centered around Bern
-    regrid_target = "swiss,590000,190000,610000,210000,1000,1000"
+    # Use a small rectangular area centered around Bern
+    regrid_target = "swiss,595000,191000,605000,209000,1000,1000"
     dst = regrid.RegularGrid.parse_regrid_operator(regrid_target)
     observed = regrid.iconremap(ds["T"], dst)
 
@@ -155,11 +155,20 @@ def test_icon2swiss_small(data_dir, fieldextra, model_name):
     assert_array_less(extreme_low, observed.values)
     assert_array_less(observed.values, extreme_high)
 
-    # Verify that geolatlon coordinates are set and centered correctly.
-    assert observed.lat.shape == (21, 21)
-    assert observed.lon.shape == (21, 21)
-    assert observed.lon[10][10] == pytest.approx(7.4386325, 1e-4)
-    assert observed.lat[10][10] == pytest.approx(46.9510828, 1e-4)
+    assert observed.y.shape == (19,)
+    assert observed.x.shape == (11,)
+    # Verify that geolatlon coordinates match expected values on the corners and center.
+    # Values are from https://epsg.io/transform#s_srs=21781&t_srs=4326
+    assert observed.sel(y=9, x=5).lon == pytest.approx(7.438632, 1e-5)
+    assert observed.sel(y=9, x=5).lat == pytest.approx(46.951082, 1e-5)
+    assert observed.sel(y=0, x=0).lon == pytest.approx(7.373052, 1e-5)
+    assert observed.sel(y=0, x=0).lat == pytest.approx(46.870106, 1e-5)
+    assert observed.sel(y=18, x=0).lon == pytest.approx(7.372851, 1e-5)
+    assert observed.sel(y=18, x=0).lat == pytest.approx(47.032019, 1e-5)
+    assert observed.sel(y=0, x=10).lon == pytest.approx(7.504215, 1e-5)
+    assert observed.sel(y=0, x=10).lat == pytest.approx(46.870107, 1e-5)
+    assert observed.sel(y=18, x=10).lon == pytest.approx(7.504410, 1e-5)
+    assert observed.sel(y=18, x=10).lat == pytest.approx(47.032020, 1e-5)
 
 
 @pytest.mark.skip(reason="the byc method in fx is not optimised (>30min on icon-ch1)")

--- a/tests/test_meteodatalab/test_regrid.py
+++ b/tests/test_meteodatalab/test_regrid.py
@@ -2,8 +2,9 @@
 import dataclasses as dc
 
 # Third-party
+import numpy as np
 import pytest
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_array_less
 
 # First-party
 from meteodatalab import data_source, grib_decoder
@@ -134,6 +135,31 @@ def test_icon2rotlatlon(data_dir, fieldextra, model_name):
     )
 
     assert_allclose(observed, fx_ds["T"], rtol=1e-4, atol=1e-4)
+
+
+@pytest.mark.data("iconremap")
+@pytest.mark.parametrize("model_name", ["icon-ch1-eps", "icon-ch2-eps"])
+def test_icon2swiss_small(data_dir, fieldextra, model_name):
+    datafiles = [str(data_dir / f"{model_name.upper()}_lfff00000000_000")]
+    source = data_source.FileDataSource(datafiles=datafiles)
+    ds = grib_decoder.load(source, "T")
+
+    # Use a small area centered around Bern
+    regrid_target = "swiss,590000,190000,610000,210000,1000,1000"
+    dst = regrid.RegularGrid.parse_regrid_operator(regrid_target)
+    observed = regrid.iconremap(ds["T"], dst)
+
+    # Sanity check the temperature values.
+    extreme_low = np.full(observed.shape, 150)
+    extreme_high = np.full(observed.shape, 350)
+    assert_array_less(extreme_low, observed.values)
+    assert_array_less(observed.values, extreme_high)
+
+    # Verify that geolatlon coordinates are set and centered correctly.
+    assert observed.lat.shape == (21, 21)
+    assert observed.lon.shape == (21, 21)
+    assert observed.lon[10][10] == pytest.approx(7.4386325, 1e-4)
+    assert observed.lat[10][10] == pytest.approx(46.9510828, 1e-4)
 
 
 @pytest.mark.skip(reason="the byc method in fx is not optimised (>30min on icon-ch1)")


### PR DESCRIPTION
## Purpose

Fixes bugs regarding parameter ordering and cropping. Adds lon/lat coordinates to the returned xarray.

https://meteoswiss.atlassian.net/browse/OG-35

## Code changes:

- Modifies iconremap and adds a basic sanity test. The fieldextra verification is still disabled.

## Checklist
Before submitting this PR, please make sure:

- [x ] You have followed the coding standards guidelines established at [Code Review Checklist](https://meteoswiss.atlassian.net/wiki/spaces/UA/pages/20157433/Factory).
- [x ] Docstrings and type hints are added to new and updated routines, as appropriate
- [x ] All relevant documentation has been updated or added (e.g. README)
- [x ] Unit tests are added or updated for non-operator code
- [x ] New operators are properly tested

Additionally, if the PR updates the version of the package

- [N/A] The new version is properly set
- [N/A] A Tag will be created after the bump

## Review
For the review process follow the guidelines at [Checklist](https://meteoswiss.atlassian.net/wiki/spaces/UA/pages/20156488/Code+Review)
