### PR TITLE
Remove CSCS directory from library

### DIFF
--- a/src/meteodatalab/icon_grid.py
+++ b/src/meteodatalab/icon_grid.py
@@ -13,42 +13,6 @@ GRID_ID = {
     "icon-ch1-eps": UUID("17643da2-5749-59b6-44d2-54a3cd6e2bc0"),
     "icon-ch2-eps": UUID("bbbd5a09-8554-9924-3c7a-4aa4c8762920"),
 }
-GRID_DIR = Path("/scratch/mch/jenkins/icon/pool/data/ICON/mch/grids/")
-GRID_MAP = {
-    GRID_ID["icon-ch1-eps"]: GRID_DIR / "icon-1/icon_grid_0001_R19B08_mch.nc",
-    GRID_ID["icon-ch2-eps"]: GRID_DIR / "icon-2/icon_grid_0002_R19B07_mch.nc",
-}
-
-
-def get_icon_grid(grid_uuid: str) -> dict[str, xr.DataArray]:
-    """Get ICON native grid coordinates.
-
-    Parameters
-    ----------
-    grid_uuid : str
-        The UUID of the horizontal grid.
-
-    Raises
-    ------
-    KeyError
-        If the UUID is not found in the GRID_MAP constant.
-
-    Returns
-    -------
-    dict[str, xarray.DataArray]
-        Geodectic coordinates of the ICON grid cell centers.
-
-    """
-    grid_path = GRID_MAP.get(UUID(grid_uuid))
-
-    if grid_path is None:
-        raise KeyError
-
-    ds = xr.open_dataset(grid_path)
-
-    rad2deg = 180 / np.pi
-    result = ds[["clon", "clat"]].reset_coords() * rad2deg
-    return {"lon": result.clon, "lat": result.clat}
 
 
 def get_remap_coeffs(

--- a/src/meteodatalab/icon_grid.py
+++ b/src/meteodatalab/icon_grid.py
@@ -1,12 +1,10 @@
 """ICON native grid helper functions."""
 
 # Standard library
-from pathlib import Path
 from typing import Literal
 from uuid import UUID
 
 # Third-party
-import numpy as np
 import xarray as xr
 
 GRID_ID = {

--- a/tests/test_meteodatalab/conftest.py
+++ b/tests/test_meteodatalab/conftest.py
@@ -93,15 +93,6 @@ def fieldextra_path(machine):
 
 
 @pytest.fixture(scope="session")
-def icon_grid_paths():
-    grid_dir = Path("/scratch/mch/jenkins/icon/pool/data/ICON/mch/grids/")
-    return {
-        "icon-ch1-eps": grid_dir / "icon-1/icon_grid_0001_R19B08_mch.nc",
-        "icon-ch2-eps": grid_dir / "icon-2/icon_grid_0002_R19B07_mch.nc",
-    }
-
-
-@pytest.fixture(scope="session")
 def template_env():
     """Jinja input namelist template environment."""
     test_dir = Path(__file__).parent
@@ -135,12 +126,16 @@ def request_template():
 
 
 @pytest.fixture(scope="session")
-def icon_grid(icon_grid_paths):
+def icon_grid():
     """Load the ICON native grid for a given model."""
+    grid_dir = Path("/scratch/mch/jenkins/icon/pool/data/ICON/mch/grids/")
+    icon_grid_paths = {
+        "icon-ch1-eps": grid_dir / "icon-1/icon_grid_0001_R19B08_mch.nc",
+        "icon-ch2-eps": grid_dir / "icon-2/icon_grid_0002_R19B07_mch.nc",
+    }
 
     def f(model_name: str) -> dict[str, xr.DataArray]:
         grid_path = icon_grid_paths.get(model_name)
-
         if grid_path is None:
             raise KeyError
 

--- a/tests/test_meteodatalab/conftest.py
+++ b/tests/test_meteodatalab/conftest.py
@@ -6,6 +6,7 @@ import subprocess
 from pathlib import Path
 
 # Third-party
+import numpy as np
 import pytest
 import xarray as xr
 from jinja2 import Environment, FileSystemLoader
@@ -92,6 +93,15 @@ def fieldextra_path(machine):
 
 
 @pytest.fixture(scope="session")
+def icon_grid_paths():
+    grid_dir = Path("/scratch/mch/jenkins/icon/pool/data/ICON/mch/grids/")
+    return {
+        "icon-ch1-eps": grid_dir / "icon-1/icon_grid_0001_R19B08_mch.nc",
+        "icon-ch2-eps": grid_dir / "icon-2/icon_grid_0002_R19B07_mch.nc",
+    }
+
+
+@pytest.fixture(scope="session")
 def template_env():
     """Jinja input namelist template environment."""
     test_dir = Path(__file__).parent
@@ -121,6 +131,25 @@ def request_template():
         "time": "0300",
         "type": "ememb",
     }
+
+
+@pytest.fixture(scope="session")
+def icon_grid(icon_grid_paths):
+    """Load the ICON native grid for a given model."""
+
+    def f(model_name: str) -> dict[str, xr.DataArray]:
+        grid_path = icon_grid_paths.get(model_name)
+
+        if grid_path is None:
+            raise KeyError
+
+        ds = xr.open_dataset(grid_path)
+
+        rad2deg = 180 / np.pi
+        result = ds[["clon", "clat"]].reset_coords() * rad2deg
+        return {"lon": result.clon, "lat": result.clat}
+
+    return f
 
 
 @pytest.fixture

--- a/tests/test_meteodatalab/test_regrid.py
+++ b/tests/test_meteodatalab/test_regrid.py
@@ -65,10 +65,10 @@ def test_to_crs():
 
 @pytest.mark.data("iconremap")
 @pytest.mark.parametrize("model_name", ["icon-ch1-eps", "icon-ch2-eps"])
-def test_icon2geolatlon(data_dir, fieldextra, model_name):
+def test_icon2geolatlon(data_dir, fieldextra, model_name, icon_grid):
     datafiles = [str(data_dir / f"{model_name.upper()}_lfff00000000_000")]
     source = data_source.FileDataSource(datafiles=datafiles)
-    ds = grib_decoder.load(source, "T")
+    ds = grib_decoder.load(source, "T", icon_grid(model_name))
     original = ds["T"].attrs.copy()
 
     observed = regrid.icon2geolatlon(ds["T"])
@@ -103,10 +103,10 @@ def test_icon2geolatlon(data_dir, fieldextra, model_name):
 
 @pytest.mark.data("iconremap")
 @pytest.mark.parametrize("model_name", ["icon-ch1-eps", "icon-ch2-eps"])
-def test_icon2rotlatlon(data_dir, fieldextra, model_name):
+def test_icon2rotlatlon(data_dir, fieldextra, model_name, icon_grid):
     datafiles = [str(data_dir / f"{model_name.upper()}_lfff00000000_000")]
     source = data_source.FileDataSource(datafiles=datafiles)
-    ds = grib_decoder.load(source, "T")
+    ds = grib_decoder.load(source, "T", icon_grid(model_name))
 
     observed = regrid.icon2rotlatlon(ds["T"])
 
@@ -139,10 +139,10 @@ def test_icon2rotlatlon(data_dir, fieldextra, model_name):
 
 @pytest.mark.data("iconremap")
 @pytest.mark.parametrize("model_name", ["icon-ch1-eps", "icon-ch2-eps"])
-def test_icon2swiss_small(data_dir, fieldextra, model_name):
+def test_icon2swiss_small(data_dir, fieldextra, model_name, icon_grid):
     datafiles = [str(data_dir / f"{model_name.upper()}_lfff00000000_000")]
     source = data_source.FileDataSource(datafiles=datafiles)
-    ds = grib_decoder.load(source, "T")
+    ds = grib_decoder.load(source, "T", icon_grid(model_name))
 
     # Use a small rectangular area centered around Bern
     regrid_target = "swiss,595000,191000,605000,209000,1000,1000"
@@ -174,10 +174,10 @@ def test_icon2swiss_small(data_dir, fieldextra, model_name):
 @pytest.mark.skip(reason="the byc method in fx is not optimised (>30min on icon-ch1)")
 @pytest.mark.data("iconremap")
 @pytest.mark.parametrize("model_name", ["icon-ch1-eps", "icon-ch2-eps"])
-def test_icon2swiss(data_dir, fieldextra, model_name):
+def test_icon2swiss(data_dir, fieldextra, model_name, icon_grid):
     datafiles = [str(data_dir / f"{model_name.upper()}_lfff00000000_000")]
     source = data_source.FileDataSource(datafiles=datafiles)
-    ds = grib_decoder.load(source, "T")
+    ds = grib_decoder.load(source, "T", icon_grid(model_name))
 
     out_regrid_target = {
         "icon-ch1-eps": "swiss,255500,-159500,964500,479500,1000,1000",

--- a/tests/test_meteodatalab/test_regrid.py
+++ b/tests/test_meteodatalab/test_regrid.py
@@ -144,7 +144,7 @@ def test_icon2rotlatlon(data_dir, fieldextra, model_name, icon_grid):
 
 @pytest.mark.data("iconremap")
 @pytest.mark.parametrize("model_name", ["icon-ch1-eps", "icon-ch2-eps"])
-def test_icon2swiss_small(data_dir, fieldextra, model_name, icon_grid):
+def test_icon2swiss_small(data_dir, model_name, icon_grid):
     datafiles = [str(data_dir / f"{model_name.upper()}_lfff00000000_000")]
     source = data_source.FileDataSource(datafiles=datafiles)
     ds = grib_decoder.load(source, "T", icon_grid(model_name))


### PR DESCRIPTION
## Purpose

Removes the reference in the library to the CSCS filesystem for loading the ICON native grid. This is still done in tests where relevant (only in test_regrid.py).

## Code changes:

- Remove icon_grid.get_icon_grid
- Allow passing in coordinates when loading a grib file
- Update tests

## Checklist
Before submitting this PR, please make sure:

- [x ] You have followed the coding standards guidelines established at [Code Review Checklist](https://meteoswiss.atlassian.net/wiki/spaces/UA/pages/20157433/Factory).
- [x ] Docstrings and type hints are added to new and updated routines, as appropriate
- [x ] All relevant documentation has been updated or added (e.g. README)
- [x ] Unit tests are added or updated for non-operator code
- [N/A ] New operators are properly tested

Additionally, if the PR updates the version of the package

- [N/A ] The new version is properly set
- [N/A ] A Tag will be created after the bump

## Review
For the review process follow the guidelines at [Checklist](https://meteoswiss.atlassian.net/wiki/spaces/UA/pages/20156488/Code+Review)
