### PR TITLE
Add load grid callback

### DIFF
--- a/src/meteodatalab/grib_decoder.py
+++ b/src/meteodatalab/grib_decoder.py
@@ -235,7 +235,7 @@ def load_single_param(
         Request for data from the source in the mars language.
     grid_source: Callable[[UUID], xr.DataArray] | None
         Callable that returns an xarray containing clat and clon coordinates for the
-        horizontal grid defined by the given UUID.
+        horizontal ICON grid defined by the given UUID.
 
     Raises
     ------
@@ -277,7 +277,7 @@ def load(
         Request for data from the source in the mars language.
     grid_source: Callable[[UUID], xr.DataArray] | None
         Callable that returns an xarray containing clat and clon coordinates for the
-        horizontal grid defined by the given UUID.
+        horizontal ICON grid defined by the given UUID.
 
     Raises
     ------
@@ -315,7 +315,7 @@ class GribReader:
             Data source from which to retrieve the grib fields
         grid_source: Callable[[UUID], xr.DataArray] | None
             Callable that returns an xarray containing clat and clon coordinates for
-            the horizontal grid defined by the given UUID.
+            the horizontal ICON grid defined by the given UUID.
         ref_param : str
             name of parameter used to construct a reference grid
 
@@ -345,7 +345,7 @@ class GribReader:
             List of grib input filenames
         grid_source: Callable[[UUID], xr.DataArray] | None
             Callable that returns an xarray containing clat and clon coordinates for
-            the horizontal grid defined by the given UUID.
+            the horizontal ICON grid defined by the given UUID.
         ref_param : str
             name of parameter used to construct a reference grid
 

--- a/src/meteodatalab/grib_decoder.py
+++ b/src/meteodatalab/grib_decoder.py
@@ -82,7 +82,9 @@ def _is_ensemble(field) -> bool:
         return False
 
 
-def _get_hcoords(field, geo_coords: Callable[[UUID], xr.DataArray] | None):
+def _get_hcoords(
+    field: GribField, geo_coords: Callable[[UUID], xr.Dataset] | None
+) -> dict[str, xr.DataArray]:
     if field.metadata("gridType") == "unstructured_grid":
         grid_uuid = UUID(field.metadata("uuidOfHGrid"))
         if geo_coords is None:
@@ -135,7 +137,7 @@ class _FieldBuffer:
             self.dims = self.dims[1:]
 
     def load(
-        self, field: GribField, geo_coords: Callable[[UUID], xr.DataArray] | None
+        self, field: GribField, geo_coords: Callable[[UUID], xr.Dataset] | None
     ) -> None:
         key = _get_key(field, self.dims)
         name = field.metadata(NAME_KEY)
@@ -202,7 +204,7 @@ class _FieldBuffer:
 def _load_buffer_map(
     source: data_source.DataSource,
     request: Request,
-    geo_coords: Callable[[UUID], xr.DataArray] | None,
+    geo_coords: Callable[[UUID], xr.Dataset] | None,
 ) -> dict[str, _FieldBuffer]:
     logger.info("Retrieving request: %s", request)
     fs = source.retrieve(request)
@@ -223,7 +225,7 @@ def _load_buffer_map(
 def load_single_param(
     source: data_source.DataSource,
     request: Request,
-    geo_coords: Callable[[UUID], xr.DataArray] | None = None,
+    geo_coords: Callable[[UUID], xr.Dataset] | None = None,
 ) -> xr.DataArray:
     """Request data from a data source for a single parameter.
 
@@ -233,9 +235,9 @@ def load_single_param(
         Source to request the data from.
     request : str | tuple[str, str] | dict[str, Any] | meteodatalab.mars.Request
         Request for data from the source in the mars language.
-    geo_coords: Callable[[UUID], xr.DataArray] | None
-        Callable that returns an xarray containing clat and clon coordinates for the
-        horizontal ICON grid defined by the given UUID.
+    geo_coords: Callable[[UUID], xr.Dataset] | None
+        Callable that returns a Dataset of xarrays with the clat and clon coordinates
+        of the ICON grid defined by the given UUID.
 
     Raises
     ------
@@ -265,7 +267,7 @@ def load_single_param(
 def load(
     source: data_source.DataSource,
     request: Request,
-    geo_coords: Callable[[UUID], xr.DataArray] | None = None,
+    geo_coords: Callable[[UUID], xr.Dataset] | None = None,
 ) -> dict[str, xr.DataArray]:
     """Request data from a data source.
 
@@ -275,9 +277,9 @@ def load(
         Source to request the data from.
     request : str | tuple[str, str] | dict[str, Any] | meteodatalab.mars.Request
         Request for data from the source in the mars language.
-    geo_coords: Callable[[UUID], xr.DataArray] | None
-        Callable that returns an xarray containing clat and clon coordinates for the
-        horizontal ICON grid defined by the given UUID.
+    geo_coords: Callable[[UUID], xr.Dataset] | None
+        Callable that returns a Dataset of xarrays with the clat and clon coordinates
+        of the ICON grid defined by the given UUID.
 
     Raises
     ------
@@ -304,7 +306,7 @@ class GribReader:
     def __init__(
         self,
         source: data_source.DataSource,
-        geo_coords: Callable[[UUID], xr.DataArray] | None = None,
+        geo_coords: Callable[[UUID], xr.Dataset] | None = None,
         ref_param: Request | None = None,
     ):
         """Initialize a grib reader from a data source.
@@ -313,9 +315,9 @@ class GribReader:
         ----------
         source : data_source.DataSource
             Data source from which to retrieve the grib fields
-        geo_coords: Callable[[UUID], xr.DataArray] | None
-            Callable that returns an xarray containing clat and clon coordinates for
-            the horizontal ICON grid defined by the given UUID.
+        geo_coords: Callable[[UUID], xr.Dataset] | None
+            Callable that returns a Dataset of xarrays with the clat and clon
+            coordinates of the ICON grid defined by the given UUID.
         ref_param : str
             name of parameter used to construct a reference grid
 
@@ -334,7 +336,7 @@ class GribReader:
     def from_files(
         cls,
         datafiles: list[Path],
-        geo_coords: Callable[[UUID], xr.DataArray] | None = None,
+        geo_coords: Callable[[UUID], xr.Dataset] | None = None,
         ref_param: Request | None = None,
     ):
         """Initialize a grib reader from a list of grib files.
@@ -343,9 +345,9 @@ class GribReader:
         ----------
         datafiles : list[Path]
             List of grib input filenames
-        geo_coords: Callable[[UUID], xr.DataArray] | None
-            Callable that returns an xarray containing clat and clon coordinates for
-            the horizontal ICON grid defined by the given UUID.
+        geo_coords: Callable[[UUID], xr.Dataset] | None
+            Callable that returns a Dataset of xarrays with the clat and clon
+            coordinates of the ICON grid defined by the given UUID.
         ref_param : str
             name of parameter used to construct a reference grid
 

--- a/src/meteodatalab/grib_decoder.py
+++ b/src/meteodatalab/grib_decoder.py
@@ -83,12 +83,13 @@ def _is_ensemble(field) -> bool:
 
 def _get_hcoords(field, grid_source: icon_grid.ICONGridSource | None):
     if field.metadata("gridType") == "unstructured_grid":
+        grid_uuid = field.metadata("uuidOfHGrid")
         if grid_source is None:
             logger.warning(
-                "No grid source provided when loading data with unstructured grid."
+                "No grid source provided when loading data with unstructured grid, "
+                "falling back to balfrin grid file locations."
             )
-            return {}
-        grid_uuid = field.metadata("uuidOfHGrid")
+            return icon_grid.get_balfrin_grid_source().load(grid_uuid)
         return grid_source.load(grid_uuid)
 
     return {

--- a/src/meteodatalab/icon_grid.py
+++ b/src/meteodatalab/icon_grid.py
@@ -17,7 +17,7 @@ GRID_UUID_TO_MODEL = {
 }
 
 
-def load_grid_from_file(uuid: UUID, grid_paths: dict[UUID, Path]) -> xr.DataArray:
+def load_grid_from_file(uuid: UUID, grid_paths: dict[UUID, Path]) -> xr.Dataset:
     """Load the clat and clon grid coordinates from .nc format file.
 
     Parameters
@@ -34,8 +34,9 @@ def load_grid_from_file(uuid: UUID, grid_paths: dict[UUID, Path]) -> xr.DataArra
 
     Returns
     -------
-    xarray.DataArray
-        Geodetic coordinates of the ICON grid cell centers for the model.
+    xarray.Dataset
+        Dataset containing clon and clat coordinates of the ICON grid cell centers for
+        the model.
 
     """
     grid_path = grid_paths.get(uuid)
@@ -48,7 +49,7 @@ def load_grid_from_file(uuid: UUID, grid_paths: dict[UUID, Path]) -> xr.DataArra
     return ds[["clon", "clat"]].reset_coords() * rad2deg
 
 
-def load_grid_from_balfrin() -> Callable[[UUID], xr.DataArray]:
+def load_grid_from_balfrin() -> Callable[[UUID], xr.Dataset]:
     """Return a grid source to load grid files when running on balfrin."""
     grid_dir = Path("/scratch/mch/jenkins/icon/pool/data/ICON/mch/grids/")
     grid_paths = {

--- a/src/meteodatalab/icon_grid.py
+++ b/src/meteodatalab/icon_grid.py
@@ -1,6 +1,7 @@
 """ICON native grid helper functions."""
 
 # Standard library
+from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Literal
 from uuid import UUID
@@ -9,46 +10,94 @@ from uuid import UUID
 import numpy as np
 import xarray as xr
 
-GRID_ID = {
-    "icon-ch1-eps": UUID("17643da2-5749-59b6-44d2-54a3cd6e2bc0"),
-    "icon-ch2-eps": UUID("bbbd5a09-8554-9924-3c7a-4aa4c8762920"),
-}
-GRID_DIR = Path("/scratch/mch/jenkins/icon/pool/data/ICON/mch/grids/")
-GRID_MAP = {
-    GRID_ID["icon-ch1-eps"]: GRID_DIR / "icon-1/icon_grid_0001_R19B08_mch.nc",
-    GRID_ID["icon-ch2-eps"]: GRID_DIR / "icon-2/icon_grid_0002_R19B07_mch.nc",
+GRID_UUID_TO_MODEL = {
+    UUID("17643da2-5749-59b6-44d2-54a3cd6e2bc0"): "icon-ch1-eps",
+    UUID("bbbd5a09-8554-9924-3c7a-4aa4c8762920"): "icon-ch2-eps",
 }
 
 
-def get_icon_grid(grid_uuid: str) -> dict[str, xr.DataArray]:
-    """Get ICON native grid coordinates.
+class ICONGridSource(ABC):
 
-    Parameters
-    ----------
-    grid_uuid : str
-        The UUID of the horizontal grid.
+    @abstractmethod
+    def _load_clat_clon(self, model_name: str) -> xr.DataArray:
+        """Load the clat and clon grid coordinates.
 
-    Raises
-    ------
-    KeyError
-        If the UUID is not found in the GRID_MAP constant.
+        Parameters
+        ----------
+        model_name: str
+            The name of the model that the grid applies to. Expected to be one of
+            "icon-ch1-eps" or "icon-ch2-eps".
 
-    Returns
-    -------
-    dict[str, xarray.DataArray]
-        Geodectic coordinates of the ICON grid cell centers.
+        Returns
+        -------
+        xarray.DataArray
+            Coordinates in radians of the ICON grid cell centers for the model.
 
-    """
-    grid_path = GRID_MAP.get(UUID(grid_uuid))
+        """
+        pass
 
-    if grid_path is None:
-        raise KeyError
+    def load(self, grid_uuid: str) -> dict[str, xr.DataArray]:
+        """Get ICON native grid coordinates.
 
-    ds = xr.open_dataset(grid_path)
+        Parameters
+        ----------
+        grid_uuid : str
+            The UUID of the horizontal grid.
 
-    rad2deg = 180 / np.pi
-    result = ds[["clon", "clat"]].reset_coords() * rad2deg
-    return {"lon": result.clon, "lat": result.clat}
+        Raises
+        ------
+        KeyError
+            If the UUID does not match a known model.
+
+        Returns
+        -------
+        dict[str, xarray.DataArray]
+            Geodetic coordinates of the ICON grid cell centers.
+
+        """
+        model_name = GRID_UUID_TO_MODEL.get(UUID(grid_uuid))
+
+        if model_name is None:
+            raise KeyError("Unknown UUID: ", grid_uuid)
+        ds = self._load_clat_clon(model_name)
+
+        rad2deg = 180 / np.pi
+        result = ds[["clon", "clat"]].reset_coords() * rad2deg
+        return {"lon": result.clon, "lat": result.clat}
+
+
+class FileGridSource(ICONGridSource):
+    def __init__(self, grid_paths: dict[str, Path]):
+        self._grid_paths = grid_paths
+
+    def _load_grid_from_file(self, grid_path: Path) -> xr.DataArray:
+        return xr.open_dataset(grid_path)
+
+    def _load_clat_clon(self, model_name: str) -> xr.DataArray:
+        grid_path = self._grid_paths.get(model_name)
+        if grid_path is None:
+            raise KeyError("No grid file for model %s.", model_name)
+        return self._load_grid_from_file(grid_path)
+
+
+class CSCSGridSource(FileGridSource):
+    """Special case of FileGridSource with file locations in CSCS."""
+
+    GRID_DIR = Path("/scratch/mch/jenkins/icon/pool/data/ICON/mch/grids/")
+    GRID_MAP = {
+        "icon-ch1-eps": GRID_DIR / "icon-1/icon_grid_0001_R19B08_mch.nc",
+        "icon-ch2-eps": GRID_DIR / "icon-2/icon_grid_0002_R19B07_mch.nc",
+    }
+
+    def __init__(self):
+        super().__init__(self.GRID_MAP)
+
+
+class OGDGridSource(ICONGridSource):
+    def _load_clat_clon(self, model_name: str) -> xr.DataArray:
+        raise NotImplementedError(
+            "Loading the ICON grid from OGD is not yet implemented."
+        )
 
 
 def get_remap_coeffs(
@@ -74,7 +123,7 @@ def get_remap_coeffs(
         Dataset of the remap indices and weights.
 
     """
-    model = {v.hex: k for k, v in GRID_ID.items()}[grid_uuid]
+    model = GRID_UUID_TO_MODEL[UUID(grid_uuid)]
     coeffs_path = (
         f"/store_new/mch/msopr/icon_workflow_2/iconremap-weights/{model}-{grid_type}.nc"
     )

--- a/src/meteodatalab/icon_grid.py
+++ b/src/meteodatalab/icon_grid.py
@@ -1,6 +1,7 @@
 """ICON native grid helper functions."""
 
 # Standard library
+import dataclasses as dc
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Literal
@@ -19,14 +20,18 @@ GRID_UUID_TO_MODEL = {
 class ICONGridSource(ABC):
 
     @abstractmethod
-    def _load_clat_clon(self, model_name: str) -> xr.DataArray:
+    def _load_clat_clon(self, grid_uuid: UUID) -> xr.DataArray:
         """Load the clat and clon grid coordinates.
 
         Parameters
         ----------
-        model_name: str
-            The name of the model that the grid applies to. Expected to be one of
-            "icon-ch1-eps" or "icon-ch2-eps".
+        grid_uuid: UUID
+            The UUID of the horizontal grid as specified in the GRIB file.
+
+        Raises
+        ------
+        KeyError
+            If the UUID does not match a known model.
 
         Returns
         -------
@@ -44,53 +49,49 @@ class ICONGridSource(ABC):
         grid_uuid : str
             The UUID of the horizontal grid.
 
-        Raises
-        ------
-        KeyError
-            If the UUID does not match a known model.
-
         Returns
         -------
         dict[str, xarray.DataArray]
             Geodetic coordinates of the ICON grid cell centers.
 
         """
-        model_name = GRID_UUID_TO_MODEL.get(UUID(grid_uuid))
-
-        if model_name is None:
-            raise KeyError("Unknown UUID: ", grid_uuid)
-        ds = self._load_clat_clon(model_name)
+        ds = self._load_clat_clon(UUID(grid_uuid))
 
         rad2deg = 180 / np.pi
         result = ds[["clon", "clat"]].reset_coords() * rad2deg
         return {"lon": result.clon, "lat": result.clat}
 
 
+@dc.dataclass
 class FileGridSource(ICONGridSource):
-    def __init__(self, grid_paths: dict[str, Path]):
-        self._grid_paths = grid_paths
+    """Source that loads ICON grid data from files.
 
-    def _load_grid_from_file(self, grid_path: Path) -> xr.DataArray:
+    Parameters
+    ----------
+    grid_paths: dict[UUID, Path]
+        Dictionary mapping from horizontal grid UUID to the path where the data file is.
+
+    """
+
+    grid_paths: dict[UUID, Path]
+
+    def _load_clat_clon(self, grid_uuid: UUID) -> xr.DataArray:
+        grid_path = self.grid_paths.get(grid_uuid)
+        if grid_path is None:
+            raise KeyError("No grid file for UUID %s.", grid_uuid)
         return xr.open_dataset(grid_path)
 
-    def _load_clat_clon(self, model_name: str) -> xr.DataArray:
-        grid_path = self._grid_paths.get(model_name)
-        if grid_path is None:
-            raise KeyError("No grid file for model %s.", model_name)
-        return self._load_grid_from_file(grid_path)
 
-
-class CSCSGridSource(FileGridSource):
-    """Special case of FileGridSource with file locations in CSCS."""
-
-    GRID_DIR = Path("/scratch/mch/jenkins/icon/pool/data/ICON/mch/grids/")
-    GRID_MAP = {
-        "icon-ch1-eps": GRID_DIR / "icon-1/icon_grid_0001_R19B08_mch.nc",
-        "icon-ch2-eps": GRID_DIR / "icon-2/icon_grid_0002_R19B07_mch.nc",
+def get_balfrin_grid_source() -> ICONGridSource:
+    """Return a grid source to load grid files when running on balfrin."""
+    grid_dir = Path("/scratch/mch/jenkins/icon/pool/data/ICON/mch/grids/")
+    grid_paths = {
+        UUID("17643da2-5749-59b6-44d2-54a3cd6e2bc0"): grid_dir
+        / "icon-1/icon_grid_0001_R19B08_mch.nc",
+        UUID("bbbd5a09-8554-9924-3c7a-4aa4c8762920"): grid_dir
+        / "icon-2/icon_grid_0002_R19B07_mch.nc",
     }
-
-    def __init__(self):
-        super().__init__(self.GRID_MAP)
+    return FileGridSource(grid_paths=grid_paths)
 
 
 class OGDGridSource(ICONGridSource):

--- a/tests/test_meteodatalab/conftest.py
+++ b/tests/test_meteodatalab/conftest.py
@@ -11,7 +11,7 @@ import xarray as xr
 from jinja2 import Environment, FileSystemLoader
 
 # First-party
-from meteodatalab.icon_grid import CSCSGridSource
+from meteodatalab.icon_grid import get_balfrin_grid_source
 
 root = Path(__file__).parents[2]
 view_path = str(root / "spack-env/.spack-env/view")
@@ -129,7 +129,7 @@ def request_template():
 
 @pytest.fixture
 def grid_source():
-    return CSCSGridSource()
+    return get_balfrin_grid_source()
 
 
 @pytest.fixture

--- a/tests/test_meteodatalab/conftest.py
+++ b/tests/test_meteodatalab/conftest.py
@@ -10,9 +10,6 @@ import pytest
 import xarray as xr
 from jinja2 import Environment, FileSystemLoader
 
-# First-party
-from meteodatalab import icon_grid
-
 root = Path(__file__).parents[2]
 view_path = str(root / "spack-env/.spack-env/view")
 os.environ["ECCODES_DIR"] = view_path
@@ -125,11 +122,6 @@ def request_template():
         "time": "0300",
         "type": "ememb",
     }
-
-
-@pytest.fixture
-def grid_source():
-    return icon_grid.load_grid_from_balfrin()
 
 
 @pytest.fixture

--- a/tests/test_meteodatalab/conftest.py
+++ b/tests/test_meteodatalab/conftest.py
@@ -10,6 +10,9 @@ import pytest
 import xarray as xr
 from jinja2 import Environment, FileSystemLoader
 
+# First-party
+from meteodatalab.icon_grid import CSCSGridSource
+
 root = Path(__file__).parents[2]
 view_path = str(root / "spack-env/.spack-env/view")
 os.environ["ECCODES_DIR"] = view_path
@@ -122,6 +125,11 @@ def request_template():
         "time": "0300",
         "type": "ememb",
     }
+
+
+@pytest.fixture
+def grid_source():
+    return CSCSGridSource()
 
 
 @pytest.fixture

--- a/tests/test_meteodatalab/conftest.py
+++ b/tests/test_meteodatalab/conftest.py
@@ -11,7 +11,7 @@ import xarray as xr
 from jinja2 import Environment, FileSystemLoader
 
 # First-party
-from meteodatalab.icon_grid import get_balfrin_grid_source
+from meteodatalab import icon_grid
 
 root = Path(__file__).parents[2]
 view_path = str(root / "spack-env/.spack-env/view")
@@ -129,7 +129,7 @@ def request_template():
 
 @pytest.fixture
 def grid_source():
-    return get_balfrin_grid_source()
+    return icon_grid.load_grid_from_balfrin()
 
 
 @pytest.fixture

--- a/tests/test_meteodatalab/test_grib_decoder.py
+++ b/tests/test_meteodatalab/test_grib_decoder.py
@@ -18,6 +18,16 @@ def test_load(params, levtype, request_template, setup_fdb):
     assert all(name == arr.parameter["shortName"] for name, arr in ds.items())
 
 
+@pytest.mark.data("iconremap")
+def test_load_icon_grid_balfrin_fallback(data_dir):
+    datafiles = [str(data_dir / "ICON-CH1-EPS_lfff00000000_000")]
+    source = data_source.FileDataSource(datafiles=datafiles)
+    ds = grib_decoder.load(source, "T")
+    assert ds.keys() == set(["T"])
+    assert "lon" in ds["T"].coords
+    assert "lat" in ds["T"].coords
+
+
 def test_save(data_dir, tmp_path):
     datafile = data_dir / "COSMO-1E/1h/const/000/lfff00000000c"
 

--- a/tests/test_meteodatalab/test_regrid.py
+++ b/tests/test_meteodatalab/test_regrid.py
@@ -18,11 +18,13 @@ except ImportError:
 
 
 @pytest.mark.data("original")
-def test_regrid(data_dir, fieldextra):
+def test_regrid(data_dir, fieldextra, grid_source):
     datafile = data_dir / "COSMO-1E/1h/ml_sl/000/lfff00000000"
     cdatafile = data_dir / "COSMO-1E/1h/const/000/lfff00000000c"
 
-    reader = grib_decoder.GribReader.from_files([cdatafile, datafile])
+    reader = grib_decoder.GribReader.from_files(
+        [cdatafile, datafile], grid_source=grid_source
+    )
     ds = reader.load_fieldnames(["T", "HHL"])
 
     hzerocl = fhzerocl(ds["T"], ds["HHL"], extrapolate=True)
@@ -70,10 +72,10 @@ def test_to_crs():
 
 @pytest.mark.data("iconremap")
 @pytest.mark.parametrize("model_name", ["icon-ch1-eps", "icon-ch2-eps"])
-def test_icon2geolatlon(data_dir, fieldextra, model_name):
+def test_icon2geolatlon(data_dir, fieldextra, model_name, grid_source):
     datafiles = [str(data_dir / f"{model_name.upper()}_lfff00000000_000")]
     source = data_source.FileDataSource(datafiles=datafiles)
-    ds = grib_decoder.load(source, "T")
+    ds = grib_decoder.load(source, "T", grid_source=grid_source)
     original = ds["T"].attrs.copy()
 
     observed = regrid.icon2geolatlon(ds["T"])
@@ -108,10 +110,10 @@ def test_icon2geolatlon(data_dir, fieldextra, model_name):
 
 @pytest.mark.data("iconremap")
 @pytest.mark.parametrize("model_name", ["icon-ch1-eps", "icon-ch2-eps"])
-def test_icon2rotlatlon(data_dir, fieldextra, model_name):
+def test_icon2rotlatlon(data_dir, fieldextra, model_name, grid_source):
     datafiles = [str(data_dir / f"{model_name.upper()}_lfff00000000_000")]
     source = data_source.FileDataSource(datafiles=datafiles)
-    ds = grib_decoder.load(source, "T")
+    ds = grib_decoder.load(source, "T", grid_source=grid_source)
 
     observed = regrid.icon2rotlatlon(ds["T"])
 
@@ -144,10 +146,10 @@ def test_icon2rotlatlon(data_dir, fieldextra, model_name):
 
 @pytest.mark.data("iconremap")
 @pytest.mark.parametrize("model_name", ["icon-ch1-eps", "icon-ch2-eps"])
-def test_icon2swiss_small(data_dir, fieldextra, model_name):
+def test_icon2swiss_small(data_dir, fieldextra, model_name, grid_source):
     datafiles = [str(data_dir / f"{model_name.upper()}_lfff00000000_000")]
     source = data_source.FileDataSource(datafiles=datafiles)
-    ds = grib_decoder.load(source, "T")
+    ds = grib_decoder.load(source, "T", grid_source=grid_source)
 
     # Use a small rectangular area centered around Bern
     regrid_target = "swiss,595000,191000,605000,209000,1000,1000"
@@ -179,10 +181,10 @@ def test_icon2swiss_small(data_dir, fieldextra, model_name):
 @pytest.mark.skip(reason="the byc method in fx is not optimised (>30min on icon-ch1)")
 @pytest.mark.data("iconremap")
 @pytest.mark.parametrize("model_name", ["icon-ch1-eps", "icon-ch2-eps"])
-def test_icon2swiss(data_dir, fieldextra, model_name):
+def test_icon2swiss(data_dir, fieldextra, model_name, grid_source):
     datafiles = [str(data_dir / f"{model_name.upper()}_lfff00000000_000")]
     source = data_source.FileDataSource(datafiles=datafiles)
-    ds = grib_decoder.load(source, "T")
+    ds = grib_decoder.load(source, "T", grid_source=grid_source)
 
     out_regrid_target = {
         "icon-ch1-eps": "swiss,255500,-159500,964500,479500,1000,1000",

--- a/tests/test_meteodatalab/test_regrid.py
+++ b/tests/test_meteodatalab/test_regrid.py
@@ -18,17 +18,17 @@ except ImportError:
 
 
 @pytest.fixture
-def grid_source():
+def geo_coords():
     return icon_grid.load_grid_from_balfrin()
 
 
 @pytest.mark.data("original")
-def test_regrid(data_dir, fieldextra, grid_source):
+def test_regrid(data_dir, fieldextra, geo_coords):
     datafile = data_dir / "COSMO-1E/1h/ml_sl/000/lfff00000000"
     cdatafile = data_dir / "COSMO-1E/1h/const/000/lfff00000000c"
 
     reader = grib_decoder.GribReader.from_files(
-        [cdatafile, datafile], grid_source=grid_source
+        [cdatafile, datafile], geo_coords=geo_coords
     )
     ds = reader.load_fieldnames(["T", "HHL"])
 
@@ -77,10 +77,10 @@ def test_to_crs():
 
 @pytest.mark.data("iconremap")
 @pytest.mark.parametrize("model_name", ["icon-ch1-eps", "icon-ch2-eps"])
-def test_icon2geolatlon(data_dir, fieldextra, model_name, grid_source):
+def test_icon2geolatlon(data_dir, fieldextra, model_name, geo_coords):
     datafiles = [str(data_dir / f"{model_name.upper()}_lfff00000000_000")]
     source = data_source.FileDataSource(datafiles=datafiles)
-    ds = grib_decoder.load(source, "T", grid_source=grid_source)
+    ds = grib_decoder.load(source, "T", geo_coords=geo_coords)
     original = ds["T"].attrs.copy()
 
     observed = regrid.icon2geolatlon(ds["T"])
@@ -115,10 +115,10 @@ def test_icon2geolatlon(data_dir, fieldextra, model_name, grid_source):
 
 @pytest.mark.data("iconremap")
 @pytest.mark.parametrize("model_name", ["icon-ch1-eps", "icon-ch2-eps"])
-def test_icon2rotlatlon(data_dir, fieldextra, model_name, grid_source):
+def test_icon2rotlatlon(data_dir, fieldextra, model_name, geo_coords):
     datafiles = [str(data_dir / f"{model_name.upper()}_lfff00000000_000")]
     source = data_source.FileDataSource(datafiles=datafiles)
-    ds = grib_decoder.load(source, "T", grid_source=grid_source)
+    ds = grib_decoder.load(source, "T", geo_coords=geo_coords)
 
     observed = regrid.icon2rotlatlon(ds["T"])
 
@@ -151,10 +151,10 @@ def test_icon2rotlatlon(data_dir, fieldextra, model_name, grid_source):
 
 @pytest.mark.data("iconremap")
 @pytest.mark.parametrize("model_name", ["icon-ch1-eps", "icon-ch2-eps"])
-def test_icon2swiss_small(data_dir, fieldextra, model_name, grid_source):
+def test_icon2swiss_small(data_dir, fieldextra, model_name, geo_coords):
     datafiles = [str(data_dir / f"{model_name.upper()}_lfff00000000_000")]
     source = data_source.FileDataSource(datafiles=datafiles)
-    ds = grib_decoder.load(source, "T", grid_source=grid_source)
+    ds = grib_decoder.load(source, "T", geo_coords=geo_coords)
 
     # Use a small rectangular area centered around Bern
     regrid_target = "swiss,595000,191000,605000,209000,1000,1000"
@@ -186,10 +186,10 @@ def test_icon2swiss_small(data_dir, fieldextra, model_name, grid_source):
 @pytest.mark.skip(reason="the byc method in fx is not optimised (>30min on icon-ch1)")
 @pytest.mark.data("iconremap")
 @pytest.mark.parametrize("model_name", ["icon-ch1-eps", "icon-ch2-eps"])
-def test_icon2swiss(data_dir, fieldextra, model_name, grid_source):
+def test_icon2swiss(data_dir, fieldextra, model_name, geo_coords):
     datafiles = [str(data_dir / f"{model_name.upper()}_lfff00000000_000")]
     source = data_source.FileDataSource(datafiles=datafiles)
-    ds = grib_decoder.load(source, "T", grid_source=grid_source)
+    ds = grib_decoder.load(source, "T", geo_coords=geo_coords)
 
     out_regrid_target = {
         "icon-ch1-eps": "swiss,255500,-159500,964500,479500,1000,1000",

--- a/tests/test_meteodatalab/test_regrid.py
+++ b/tests/test_meteodatalab/test_regrid.py
@@ -7,7 +7,7 @@ import pytest
 from numpy.testing import assert_allclose, assert_array_less
 
 # First-party
-from meteodatalab import data_source, grib_decoder
+from meteodatalab import data_source, grib_decoder, icon_grid
 from meteodatalab.operators.hzerocl import fhzerocl
 
 try:
@@ -15,6 +15,11 @@ try:
     from meteodatalab.operators import regrid
 except ImportError:
     pytest.skip("skipping regrid tests due to missing imports", allow_module_level=True)
+
+
+@pytest.fixture
+def grid_source():
+    return icon_grid.load_grid_from_balfrin()
 
 
 @pytest.mark.data("original")


### PR DESCRIPTION
## Purpose

Adds a callback to the GRIB loading for loading the ICON grid.

## Code changes:

- Changes icon_grid.get_icon_grid to a function that returns a callback to load ICON grid from file
- Plumbs a callback through the grib_decoder load API
- Adds a test that ensures backwards compatibility with existing behavior of loading from the balfrin lustre filesystem.

## Checklist
Before submitting this PR, please make sure:

- [x ] You have followed the coding standards guidelines established at [Code Review Checklist](https://meteoswiss.atlassian.net/wiki/spaces/UA/pages/20157433/Factory).
- [x ] Docstrings and type hints are added to new and updated routines, as appropriate
- [x ] All relevant documentation has been updated or added (e.g. README)
- [x ] Unit tests are added or updated for non-operator code
- [N/A ] New operators are properly tested

Additionally, if the PR updates the version of the package

- [N/A ] The new version is properly set
- [N/A ] A Tag will be created after the bump

## Review
For the review process follow the guidelines at [Checklist](https://meteoswiss.atlassian.net/wiki/spaces/UA/pages/20156488/Code+Review)
