### PR TITLE
Update staggered grid checks to first check for ICON grid

### DIFF
--- a/src/meteodatalab/cli.py
+++ b/src/meteodatalab/cli.py
@@ -10,6 +10,7 @@ import yaml
 
 # Local
 from . import __version__, grib_decoder
+from .metadata import is_staggered
 from .operators import destagger, gis, regrid
 
 
@@ -69,9 +70,9 @@ def handle_vector_fields(ds):
     for u_name, v_name in pairs:
         click.echo(f"Rotating vector field components {u_name}, {v_name} to geolatlon")
         u, v = ds[u_name], ds[v_name]
-        if u.origin_x != 0.0:
+        if is_staggered(u):
             u = destagger.destagger(u, "x")
-        if v.origin_y != 0.0:
+        if is_staggered(v):
             v = destagger.destagger(v, "y")
         if u.vref == "native" and v.vref == "native":
             u_g, v_g = gis.vref_rot2geolatlon(u, v)

--- a/src/meteodatalab/cli.py
+++ b/src/meteodatalab/cli.py
@@ -10,7 +10,7 @@ import yaml
 
 # Local
 from . import __version__, grib_decoder
-from .metadata import is_staggered
+from .metadata import is_staggered_horizontal
 from .operators import destagger, gis, regrid
 
 
@@ -70,9 +70,9 @@ def handle_vector_fields(ds):
     for u_name, v_name in pairs:
         click.echo(f"Rotating vector field components {u_name}, {v_name} to geolatlon")
         u, v = ds[u_name], ds[v_name]
-        if is_staggered(u):
+        if is_staggered_horizontal(u):
             u = destagger.destagger(u, "x")
-        if is_staggered(v):
+        if is_staggered_horizontal(v):
             v = destagger.destagger(v, "y")
         if u.vref == "native" and v.vref == "native":
             u_g, v_g = gis.vref_rot2geolatlon(u, v)

--- a/src/meteodatalab/icon_grid.py
+++ b/src/meteodatalab/icon_grid.py
@@ -51,12 +51,12 @@ def load_grid_from_file(uuid: UUID, grid_paths: dict[UUID, Path]) -> xr.Dataset:
 
 def load_grid_from_balfrin() -> Callable[[UUID], xr.Dataset]:
     """Return a grid source to load grid files when running on balfrin."""
-    grid_dir = Path("/scratch/mch/jenkins/icon/pool/data/ICON/mch/grids/")
+    grid_dir = Path("/oprusers/osm/opr.emme/data/ICON_INPUT")
     grid_paths = {
         UUID("17643da2-5749-59b6-44d2-54a3cd6e2bc0"): grid_dir
-        / "icon-1/icon_grid_0001_R19B08_mch.nc",
+        / "ICON-CH1-EPS/icon_grid_0001_R19B08_mch.nc",
         UUID("bbbd5a09-8554-9924-3c7a-4aa4c8762920"): grid_dir
-        / "icon-2/icon_grid_0002_R19B07_mch.nc",
+        / "ICON-CH2-EPS/icon_grid_0002_R19B07_mch.nc",
     }
     return partial(load_grid_from_file, grid_paths=grid_paths)
 

--- a/src/meteodatalab/icon_grid.py
+++ b/src/meteodatalab/icon_grid.py
@@ -51,12 +51,12 @@ def load_grid_from_file(uuid: UUID, grid_paths: dict[UUID, Path]) -> xr.Dataset:
 
 def load_grid_from_balfrin() -> Callable[[UUID], xr.Dataset]:
     """Return a grid source to load grid files when running on balfrin."""
-    grid_dir = Path("/oprusers/osm/opr.emme/data/ICON_INPUT")
+    grid_dir = Path("/oprusers/osm/opr/data/grid_descriptions")
     grid_paths = {
         UUID("17643da2-5749-59b6-44d2-54a3cd6e2bc0"): grid_dir
-        / "ICON-CH1-EPS/icon_grid_0001_R19B08_mch.nc",
+        / "icon_grid_0001_R19B08_mch.nc",
         UUID("bbbd5a09-8554-9924-3c7a-4aa4c8762920"): grid_dir
-        / "ICON-CH2-EPS/icon_grid_0002_R19B07_mch.nc",
+        / "icon_grid_0002_R19B07_mch.nc",
     }
     return partial(load_grid_from_file, grid_paths=grid_paths)
 

--- a/src/meteodatalab/icon_grid.py
+++ b/src/meteodatalab/icon_grid.py
@@ -51,12 +51,12 @@ def load_grid_from_file(uuid: UUID, grid_paths: dict[UUID, Path]) -> xr.Dataset:
 
 def load_grid_from_balfrin() -> Callable[[UUID], xr.Dataset]:
     """Return a grid source to load grid files when running on balfrin."""
-    grid_dir = Path("/oprusers/osm/opr/data/grid_descriptions")
+    grid_dir = Path("/scratch/mch/jenkins/icon/pool/data/ICON/mch/grids/")
     grid_paths = {
         UUID("17643da2-5749-59b6-44d2-54a3cd6e2bc0"): grid_dir
-        / "icon_grid_0001_R19B08_mch.nc",
+        / "icon-1/icon_grid_0001_R19B08_mch.nc",
         UUID("bbbd5a09-8554-9924-3c7a-4aa4c8762920"): grid_dir
-        / "icon_grid_0002_R19B07_mch.nc",
+        / "icon-2/icon_grid_0002_R19B07_mch.nc",
     }
     return partial(load_grid_from_file, grid_paths=grid_paths)
 

--- a/src/meteodatalab/metadata.py
+++ b/src/meteodatalab/metadata.py
@@ -161,7 +161,7 @@ def _uses_icon_grid(metadata: Metadata) -> bool:
     return metadata.get("centre", default="") == "lssw" and (
         metadata.get("generatingProcessIdentifier", default=0) == 141
         or metadata.get("generatingProcessIdentifier", default=0) == 142
-    )
+    ) and metadata("gridType") == "unstructured_grid"
 
 
 def set_origin_xy(ds: dict[str, xr.DataArray], ref_param: str) -> None:
@@ -245,8 +245,8 @@ def extract_hcoords(metadata: Metadata) -> dict[str, xr.DataArray]:
     }
 
 
-def is_staggered(field: xr.DataArray) -> bool:
-    """Determine if the field is on a staggered grid.
+def is_staggered_horizontal(field: xr.DataArray) -> bool:
+    """Determine if the field is on a staggered horizontal grid.
 
     Parameters
     ----------
@@ -261,7 +261,7 @@ def is_staggered(field: xr.DataArray) -> bool:
     Returns
     -------
     bool
-        True if the field is on a staggered grid.
+        True if the field is on a staggered horizontal grid.
 
     """
     if _uses_icon_grid(field.metadata):

--- a/src/meteodatalab/metadata.py
+++ b/src/meteodatalab/metadata.py
@@ -164,7 +164,7 @@ def _uses_icon_grid(metadata: Metadata) -> bool:
             metadata.get("generatingProcessIdentifier", default=0) == 141
             or metadata.get("generatingProcessIdentifier", default=0) == 142
         )
-        and metadata("gridType") == "unstructured_grid"
+        and metadata.get("gridType") == "unstructured_grid"
     )
 
 

--- a/src/meteodatalab/metadata.py
+++ b/src/meteodatalab/metadata.py
@@ -2,6 +2,7 @@
 
 # Standard library
 import dataclasses as dc
+import logging
 import typing
 
 # Third-party
@@ -11,6 +12,9 @@ from earthkit.data.core.metadata import Metadata  # type: ignore
 
 # Local
 from . import grib_decoder
+
+_logger = logging.getLogger(__name__)
+
 
 VCOORD_TYPE = {
     "generalVertical": ("model_level", -0.5),
@@ -140,6 +144,26 @@ def compute_origin(ref_grid: Grid, field: xr.DataArray) -> dict[str, float]:
     }
 
 
+def _uses_icon_grid(metadata: Metadata) -> bool:
+    """Determine if the data is on a MeteoSwiss ICON grid.
+
+    Parameters
+    ----------
+    metadata : Metadata
+        GRIB metadata containing the grid definition.
+
+    Returns
+    -------
+    bool
+        True if the data was created by an MCH ICON forecast.
+
+    """
+    return metadata.get("centre", default="") == "lssw" and (
+        metadata.get("generatingProcessIdentifier", default=0) == 141
+        or metadata.get("generatingProcessIdentifier", default=0) == 142
+    )
+
+
 def set_origin_xy(ds: dict[str, xr.DataArray], ref_param: str) -> None:
     """Set horizontal components of the origin attribute.
 
@@ -158,6 +182,14 @@ def set_origin_xy(ds: dict[str, xr.DataArray], ref_param: str) -> None:
     """
     if ref_param not in ds:
         raise KeyError(f"ref_param {ref_param} not present in dataset.")
+
+    if _uses_icon_grid(ds[ref_param].metadata):
+        _logger.warning(
+            "Data is on the ICON grid, not setting origin values. "
+            "Setting the origin components is intended for support with horizontal "
+            "grid staggering, which is not used in the output of the ICON model."
+        )
+        return
 
     ref_grid = load_grid_reference(ds[ref_param].metadata)
     for field in ds.values():
@@ -211,3 +243,30 @@ def extract_hcoords(metadata: Metadata) -> dict[str, xr.DataArray]:
             dims=("y", "x"), data=geo.longitudes().reshape(geo.shape())
         ),
     }
+
+
+def is_staggered(field: xr.DataArray) -> bool:
+    """Determine if the field is on a staggered grid.
+
+    Parameters
+    ----------
+    field: xr.DataArray
+        Field containing the grid definition.
+
+    Raises
+    ------
+    ValueError
+        if the field is a on regular grid without origin_x and origin_y set.
+
+    Returns
+    -------
+    bool
+        True if the field is on a staggered grid.
+
+    """
+    if _uses_icon_grid(field.metadata):
+        return False
+
+    if "origin_x" not in field.attrs or "origin_y" not in field.attrs:
+        raise ValueError("Field is missing origin, run set_origin_xy on the data set.")
+    return field.origin_x != 0.0 or field.origin_y != 0.0

--- a/src/meteodatalab/metadata.py
+++ b/src/meteodatalab/metadata.py
@@ -158,10 +158,14 @@ def _uses_icon_grid(metadata: Metadata) -> bool:
         True if the data was created by an MCH ICON forecast.
 
     """
-    return metadata.get("centre", default="") == "lssw" and (
-        metadata.get("generatingProcessIdentifier", default=0) == 141
-        or metadata.get("generatingProcessIdentifier", default=0) == 142
-    ) and metadata("gridType") == "unstructured_grid"
+    return (
+        metadata.get("centre", default="") == "lssw"
+        and (
+            metadata.get("generatingProcessIdentifier", default=0) == 141
+            or metadata.get("generatingProcessIdentifier", default=0) == 142
+        )
+        and metadata("gridType") == "unstructured_grid"
+    )
 
 
 def set_origin_xy(ds: dict[str, xr.DataArray], ref_param: str) -> None:

--- a/src/meteodatalab/operators/curl.py
+++ b/src/meteodatalab/operators/curl.py
@@ -9,6 +9,7 @@ import xarray as xr
 
 # Local
 from .. import physical_constants as pc
+from ..metadata import is_staggered
 from . import diff
 from .destagger import destagger
 from .total_diff import TotalDiff
@@ -27,8 +28,8 @@ def curl(
     tgrlat = cast(xr.DataArray, np.tan(rlat))
 
     # compute weighted derivatives for FD
-    u_f = destagger(u, "x") if u.origin_x != 0.0 else u
-    v_f = destagger(v, "y") if v.origin_y != 0.0 else v
+    u_f = destagger(u, "x") if is_staggered(u) else u
+    v_f = destagger(v, "y") if is_staggered(v) else v
     w_f = destagger(w, "z")
 
     du_dz = diff.dz(u_f)
@@ -64,8 +65,8 @@ def curl_alt(
     acrlat = 1 / (np.cos(rlat) * pc.earth_radius)
     tgrlat = np.tan(rlat)
 
-    u_f = destagger(u, "x")
-    v_f = destagger(v, "y")
+    u_f = destagger(u, "x") if is_staggered(u) else u
+    v_f = destagger(v, "y") if is_staggered(v) else v
     w_f = destagger(w, "z")
 
     du_dphi = np.gradient(u_f, td.dlat, axis=-2)

--- a/src/meteodatalab/operators/curl.py
+++ b/src/meteodatalab/operators/curl.py
@@ -9,7 +9,7 @@ import xarray as xr
 
 # Local
 from .. import physical_constants as pc
-from ..metadata import is_staggered
+from ..metadata import is_staggered_horizontal
 from . import diff
 from .destagger import destagger
 from .total_diff import TotalDiff
@@ -28,8 +28,8 @@ def curl(
     tgrlat = cast(xr.DataArray, np.tan(rlat))
 
     # compute weighted derivatives for FD
-    u_f = destagger(u, "x") if is_staggered(u) else u
-    v_f = destagger(v, "y") if is_staggered(v) else v
+    u_f = destagger(u, "x") if is_staggered_horizontal(u) else u
+    v_f = destagger(v, "y") if is_staggered_horizontal(v) else v
     w_f = destagger(w, "z")
 
     du_dz = diff.dz(u_f)
@@ -65,8 +65,8 @@ def curl_alt(
     acrlat = 1 / (np.cos(rlat) * pc.earth_radius)
     tgrlat = np.tan(rlat)
 
-    u_f = destagger(u, "x") if is_staggered(u) else u
-    v_f = destagger(v, "y") if is_staggered(v) else v
+    u_f = destagger(u, "x") if is_staggered_horizontal(u) else u
+    v_f = destagger(v, "y") if is_staggered_horizontal(v) else v
     w_f = destagger(w, "z")
 
     du_dphi = np.gradient(u_f, td.dlat, axis=-2)

--- a/src/meteodatalab/operators/gis.py
+++ b/src/meteodatalab/operators/gis.py
@@ -207,13 +207,18 @@ def vref_rot2geolatlon(
     v : xarray.DataArray
         y component of the vector field w.r.t. a rotated lat lon grid.
 
+    Raises
+    ------
+    ValueError
+        if either field is on a staggered grid.
+
     Returns
     -------
     tuple[xarray.DataArray, xarray.DataArray]
         x and y components of the vector field w.r.t. the geo lat lon coords.
 
     """
-    if u.origin_x != 0.0 or v.origin_y != 0.0:
+    if metadata.is_staggered(u) or metadata.is_staggered(v):
         raise ValueError("The vector fields must be destaggered.")
 
     grid = get_grid(u.geography)

--- a/src/meteodatalab/operators/gis.py
+++ b/src/meteodatalab/operators/gis.py
@@ -210,7 +210,7 @@ def vref_rot2geolatlon(
     Raises
     ------
     ValueError
-        if either field is on a staggered grid.
+        if either field is on a staggered grid or other than rotated lat lon.
 
     Returns
     -------
@@ -220,6 +220,11 @@ def vref_rot2geolatlon(
     """
     if metadata.is_staggered_horizontal(u) or metadata.is_staggered_horizontal(v):
         raise ValueError("The vector fields must be destaggered.")
+    if (
+        u.metadata.get("gridDefinitionTemplateNumber") != 1
+        or v.metadata.get("gridDefinitionTemplateNumber") != 1
+    ):
+        raise ValueError("The vector fields must be defined on a rotated lat lon grid.")
 
     grid = get_grid(u.geography)
     lon, lat = rot2geolatlon(grid)

--- a/src/meteodatalab/operators/gis.py
+++ b/src/meteodatalab/operators/gis.py
@@ -218,7 +218,7 @@ def vref_rot2geolatlon(
         x and y components of the vector field w.r.t. the geo lat lon coords.
 
     """
-    if metadata.is_staggered(u) or metadata.is_staggered(v):
+    if metadata.is_staggered_horizontal(u) or metadata.is_staggered_horizontal(v):
         raise ValueError("The vector fields must be destaggered.")
 
     grid = get_grid(u.geography)

--- a/src/meteodatalab/operators/wind.py
+++ b/src/meteodatalab/operators/wind.py
@@ -5,7 +5,7 @@ import numpy as np
 import xarray as xr
 
 # Local
-from ..metadata import override
+from ..metadata import is_staggered, override
 from .gis import vref_rot2geolatlon
 
 
@@ -35,7 +35,7 @@ def speed(u: xr.DataArray, v: xr.DataArray) -> xr.DataArray:
         the horizontal wind speed [m/s].
 
     """
-    if u.origin_x != 0.0 or v.origin_y != 0.0:
+    if is_staggered(u) or is_staggered(v):
         raise ValueError("The wind components should not be staggered.")
 
     name = {"U": "SP", "U_10M": "SP_10M"}[u.parameter["shortName"]]
@@ -50,7 +50,7 @@ def direction(u: xr.DataArray, v: xr.DataArray) -> xr.DataArray:
 
     Note that terrain following grid deformation is not accounted for.
     The input fields are required to be located on the mass points
-    of a regular grid defined in the rotated latlon coordinate system.
+    of a grid defined in the rotated or geo latlon coordinate system.
     The preferred unit is meters per second but any consistent unit system
     acceptable.
 
@@ -65,7 +65,7 @@ def direction(u: xr.DataArray, v: xr.DataArray) -> xr.DataArray:
     ------
     ValueError
         if any of the input fields is located on staggered points or on any
-        other than a regular grid in the rotated latlon coordinate system.
+        other than a grid in the rotated or geo latlon coordinate system.
 
     Returns
     -------
@@ -74,7 +74,11 @@ def direction(u: xr.DataArray, v: xr.DataArray) -> xr.DataArray:
 
     """
     rad2deg = 180 / np.pi
-    u_g, v_g = vref_rot2geolatlon(u, v)
+    if u.vref == "geo" and v.vref == "geo":
+        u_g = u
+        v_g = v
+    else:
+        u_g, v_g = vref_rot2geolatlon(u, v)
     name = {"U": "DD", "U_10M": "DD_10M"}[u.parameter["shortName"]]
     return xr.DataArray(
         rad2deg * np.arctan2(u_g, v_g) + 180,

--- a/tests/test_meteodatalab/conftest.py
+++ b/tests/test_meteodatalab/conftest.py
@@ -10,6 +10,9 @@ import pytest
 import xarray as xr
 from jinja2 import Environment, FileSystemLoader
 
+# First-party
+from meteodatalab import icon_grid
+
 root = Path(__file__).parents[2]
 view_path = str(root / "spack-env/.spack-env/view")
 os.environ["ECCODES_DIR"] = view_path
@@ -157,3 +160,8 @@ def fieldextra(tmp_path, data_dir, template_env, fieldextra_path):
         ]
 
     return f
+
+
+@pytest.fixture
+def geo_coords():
+    return icon_grid.load_grid_from_balfrin()

--- a/tests/test_meteodatalab/fieldextra_templates/test_wind_icon.nl
+++ b/tests/test_meteodatalab/fieldextra_templates/test_wind_icon.nl
@@ -1,0 +1,36 @@
+&RunSpecification
+ strict_nl_parsing=.true.
+ verbosity="moderate"
+/
+
+&GlobalResource
+ dictionary="{{ resources }}/dictionary_icon.txt"
+ grib_definition_path="{{ resources }}/eccodes_definitions_cosmo",
+                      "{{ resources }}/eccodes_definitions_vendor"
+ grib2_sample="{{ resources }}/eccodes_samples/COSMO_GRIB2_default.tmpl"
+ rttov_coefs_path="{{ resources }}/rttov_coefficients"
+ icon_grid_description="{{ icon_grid_description }}"
+/
+
+&GlobalSettings
+ default_model_name="{{ model_name }}"
+/
+
+&ModelSpecification
+ model_name="{{ model_name }}"
+ earth_axis_large=6371229.
+ earth_axis_small=6371229.
+/
+
+&Process
+  in_file  = "{{ file.inputi }}"
+  out_file = "{{ file.output }}"
+  out_type = "NETCDF"
+  tstart   = 0
+  tstop    = 0
+  tincr    = 1
+/
+&Process in_field = "U_10M" /
+&Process in_field = "V_10M" /
+&Process out_field = "FF_10M"  /
+&Process out_field = "DD_10M" /

--- a/tests/test_meteodatalab/test_metadata.py
+++ b/tests/test_meteodatalab/test_metadata.py
@@ -1,0 +1,37 @@
+# Third-party
+import pytest
+
+# First-party
+from meteodatalab.grib_decoder import load
+from meteodatalab.data_source import FileDataSource
+from meteodatalab.metadata import set_origin_xy, is_staggered
+from meteodatalab.operators.destagger import destagger
+
+
+def test_staggered_cosmo_data(data_dir):
+    datafile = data_dir / "COSMO-1E/1h/ml_sl/000/lfff00000000"
+    cdatafile = data_dir / "COSMO-1E/1h/const/000/lfff00000000c"
+
+    source = FileDataSource(datafiles=[cdatafile, datafile])
+    ds = load(source, {"param": ["U", "V", "HHL", "T"]})
+    
+    with pytest.raises(ValueError, match="run set_origin_xy"):
+        is_staggered(ds["U"])
+
+    set_origin_xy(ds, ref_param="HHL")
+
+    assert is_staggered(ds["U"])
+    assert is_staggered(ds["V"])
+    assert not is_staggered(ds["HHL"])
+    assert not is_staggered(ds["T"])
+
+
+@pytest.mark.data("iconremap")
+def test_icon_data_not_staggered(data_dir, geo_coords):
+    datafiles = [str(data_dir / "ICON-CH1-EPS_lfff00000000_000")]
+    source = FileDataSource(datafiles=datafiles)
+    ds = load(source, {"param": ["U", "V", "T"]}, geo_coords=geo_coords)
+
+    assert not is_staggered(ds["U"])
+    assert not is_staggered(ds["V"])
+    assert not is_staggered(ds["T"])

--- a/tests/test_meteodatalab/test_metadata.py
+++ b/tests/test_meteodatalab/test_metadata.py
@@ -4,7 +4,7 @@ import pytest
 # First-party
 from meteodatalab.data_source import FileDataSource
 from meteodatalab.grib_decoder import load
-from meteodatalab.metadata import is_staggered, set_origin_xy
+from meteodatalab.metadata import is_staggered_horizontal, set_origin_xy
 
 
 def test_staggered_cosmo_data(data_dir):
@@ -15,14 +15,14 @@ def test_staggered_cosmo_data(data_dir):
     ds = load(source, {"param": ["U", "V", "HHL", "T"]})
 
     with pytest.raises(ValueError, match="run set_origin_xy"):
-        is_staggered(ds["U"])
+        is_staggered_horizontal(ds["U"])
 
     set_origin_xy(ds, ref_param="HHL")
 
-    assert is_staggered(ds["U"])
-    assert is_staggered(ds["V"])
-    assert not is_staggered(ds["HHL"])
-    assert not is_staggered(ds["T"])
+    assert is_staggered_horizontal(ds["U"])
+    assert is_staggered_horizontal(ds["V"])
+    assert not is_staggered_horizontal(ds["HHL"])
+    assert not is_staggered_horizontal(ds["T"])
 
 
 @pytest.mark.data("iconremap")
@@ -31,6 +31,6 @@ def test_icon_data_not_staggered(data_dir, geo_coords):
     source = FileDataSource(datafiles=datafiles)
     ds = load(source, {"param": ["U", "V", "T"]}, geo_coords=geo_coords)
 
-    assert not is_staggered(ds["U"])
-    assert not is_staggered(ds["V"])
-    assert not is_staggered(ds["T"])
+    assert not is_staggered_horizontal(ds["U"])
+    assert not is_staggered_horizontal(ds["V"])
+    assert not is_staggered_horizontal(ds["T"])

--- a/tests/test_meteodatalab/test_metadata.py
+++ b/tests/test_meteodatalab/test_metadata.py
@@ -2,10 +2,9 @@
 import pytest
 
 # First-party
-from meteodatalab.grib_decoder import load
 from meteodatalab.data_source import FileDataSource
-from meteodatalab.metadata import set_origin_xy, is_staggered
-from meteodatalab.operators.destagger import destagger
+from meteodatalab.grib_decoder import load
+from meteodatalab.metadata import is_staggered, set_origin_xy
 
 
 def test_staggered_cosmo_data(data_dir):
@@ -14,7 +13,7 @@ def test_staggered_cosmo_data(data_dir):
 
     source = FileDataSource(datafiles=[cdatafile, datafile])
     ds = load(source, {"param": ["U", "V", "HHL", "T"]})
-    
+
     with pytest.raises(ValueError, match="run set_origin_xy"):
         is_staggered(ds["U"])
 

--- a/tests/test_meteodatalab/test_regrid.py
+++ b/tests/test_meteodatalab/test_regrid.py
@@ -86,10 +86,10 @@ def test_icon2geolatlon(data_dir, fieldextra, model_name, geo_coords):
         "icon-ch1-eps": "geolatlon,5500000,43600000,16900000,50000000,10000,10000",
         "icon-ch2-eps": "geolatlon,5500000,43600000,16900000,50000000,20000,20000",
     }
-    root = "/oprusers/osm/opr.emme/data/ICON_INPUT"
+    root = "/oprusers/osm/opr/data/grid_descriptions"
     icon_grid_description = {
-        "icon-ch1-eps": f"{root}/ICON-CH1-EPS/icon_grid_0001_R19B08_mch.nc",
-        "icon-ch2-eps": f"{root}/ICON-CH2-EPS/icon_grid_0002_R19B07_mch.nc",
+        "icon-ch1-eps": f"{root}/icon_grid_0001_R19B08_mch.nc",
+        "icon-ch2-eps": f"{root}/icon_grid_0002_R19B07_mch.nc",
     }
 
     fx_ds = fieldextra(
@@ -123,10 +123,10 @@ def test_icon2rotlatlon(data_dir, fieldextra, model_name, geo_coords):
         "icon-ch2-eps": "rotlatlon,353180000,-4420000,4800000,3360000,20000,20000,"
         "190000000,43000000",
     }
-    root = "/oprusers/osm/opr.emme/data/ICON_INPUT"
+    root = "/oprusers/osm/opr/data/grid_descriptions"
     icon_grid_description = {
-        "icon-ch1-eps": f"{root}/ICON-CH1-EPS/icon_grid_0001_R19B08_mch.nc",
-        "icon-ch2-eps": f"{root}/ICON-CH2-EPS/icon_grid_0002_R19B07_mch.nc",
+        "icon-ch1-eps": f"{root}/icon_grid_0001_R19B08_mch.nc",
+        "icon-ch2-eps": f"{root}/icon_grid_0002_R19B07_mch.nc",
     }
 
     fx_ds = fieldextra(
@@ -194,10 +194,10 @@ def test_icon2swiss(data_dir, fieldextra, model_name, geo_coords):
     dst = regrid.RegularGrid.parse_regrid_operator(out_regrid_target[model_name])
     observed = regrid.iconremap(ds["T"], dst)
 
-    root = "/oprusers/osm/opr.emme/data/ICON_INPUT"
+    root = "/oprusers/osm/opr/data/grid_descriptions"
     icon_grid_description = {
-        "icon-ch1-eps": f"{root}/ICON-CH1-EPS/icon_grid_0001_R19B08_mch.nc",
-        "icon-ch2-eps": f"{root}/ICON-CH2-EPS/icon_grid_0002_R19B07_mch.nc",
+        "icon-ch1-eps": f"{root}/icon_grid_0001_R19B08_mch.nc",
+        "icon-ch2-eps": f"{root}/icon_grid_0002_R19B07_mch.nc",
     }
 
     fx_ds = fieldextra(

--- a/tests/test_meteodatalab/test_regrid.py
+++ b/tests/test_meteodatalab/test_regrid.py
@@ -7,7 +7,7 @@ import pytest
 from numpy.testing import assert_allclose, assert_array_less
 
 # First-party
-from meteodatalab import data_source, grib_decoder, icon_grid
+from meteodatalab import data_source, grib_decoder
 from meteodatalab.operators.hzerocl import fhzerocl
 
 try:
@@ -15,11 +15,6 @@ try:
     from meteodatalab.operators import regrid
 except ImportError:
     pytest.skip("skipping regrid tests due to missing imports", allow_module_level=True)
-
-
-@pytest.fixture
-def geo_coords():
-    return icon_grid.load_grid_from_balfrin()
 
 
 @pytest.mark.data("original")

--- a/tests/test_meteodatalab/test_wind.py
+++ b/tests/test_meteodatalab/test_wind.py
@@ -90,6 +90,7 @@ def test_wind_icon(data_dir, fieldextra, model_name, geo_coords):
     )
 
     assert_allclose(ff_10m, fx_ds["FF_10M"], rtol=1e-6)
+    assert_allclose(dd_10m, fx_ds["DD_10M"], atol=1e-4)
 
     assert ff_10m.parameter == {
         "centre": "lssw",

--- a/tests/test_meteodatalab/test_wind.py
+++ b/tests/test_meteodatalab/test_wind.py
@@ -77,10 +77,10 @@ def test_wind_icon(data_dir, fieldextra, model_name, geo_coords):
         "inputi": data_dir / f"{model_name.upper()}_lfff<DDHH>0000_000",
         "output": "<HH>_outfile.nc",
     }
-    root = "/oprusers/osm/opr.emme/data/ICON_INPUT"
+    root = "/oprusers/osm/opr/data/grid_descriptions"
     icon_grid_description = {
-        "icon-ch1-eps": f"{root}/ICON-CH1-EPS/icon_grid_0001_R19B08_mch.nc",
-        "icon-ch2-eps": f"{root}/ICON-CH2-EPS/icon_grid_0002_R19B07_mch.nc",
+        "icon-ch1-eps": f"{root}/icon_grid_0001_R19B08_mch.nc",
+        "icon-ch2-eps": f"{root}/icon_grid_0002_R19B07_mch.nc",
     }
     fx_ds = fieldextra(
         "wind_icon",

--- a/tests/test_meteodatalab/test_wind.py
+++ b/tests/test_meteodatalab/test_wind.py
@@ -4,8 +4,8 @@ from numpy.testing import assert_allclose
 
 # First-party
 from meteodatalab.data_cache import DataCache
-from meteodatalab.data_source import FDBDataSource
-from meteodatalab.grib_decoder import GribReader
+from meteodatalab.data_source import FDBDataSource, FileDataSource
+from meteodatalab.grib_decoder import load
 from meteodatalab.metadata import set_origin_xy
 from meteodatalab.operators import wind
 
@@ -27,8 +27,8 @@ def data(work_dir, request_template, setup_fdb):
 
 def test_wind(data, fieldextra):
     cache = data
-    reader = GribReader.from_files(cache.populated_files)
-    ds = reader.load_fieldnames(["U_10M", "V_10M"])
+    source = FileDataSource(datafiles=[str(f) for f in cache.populated_files])
+    ds = load(source, {"param": ["U_10M", "V_10M"]})
     set_origin_xy(ds, ref_param="U_10M")
 
     u_10m = ds["U_10M"].isel(z=0)
@@ -42,6 +42,54 @@ def test_wind(data, fieldextra):
 
     assert_allclose(ff_10m, fx_ds["FF_10M"], rtol=1e-6)
     assert_allclose(dd_10m, fx_ds["DD_10M"], atol=1e-4)
+
+    assert ff_10m.parameter == {
+        "centre": "lssw",
+        "name": "Wind speed (SP_10M)",
+        "paramId": 500025,
+        "shortName": "SP_10M",
+        "units": "m s-1",
+    }
+
+    assert dd_10m.parameter == {
+        "centre": "lssw",
+        "name": "Wind Direction (DD_10M)",
+        "paramId": 500023,
+        "shortName": "DD_10M",
+        "units": "degree true",
+    }
+
+
+@pytest.mark.data("iconremap")
+@pytest.mark.parametrize("model_name", ["icon-ch1-eps", "icon-ch2-eps"])
+def test_wind_icon(data_dir, fieldextra, model_name, geo_coords):
+    datafiles = [str(data_dir / f"{model_name.upper()}_lfff00000000_000")]
+    source = FileDataSource(datafiles=datafiles)
+    ds = load(source, {"param": ["U_10M", "V_10M"]}, geo_coords=geo_coords)
+
+    u_10m = ds["U_10M"].isel(z=0)
+    v_10m = ds["V_10M"].isel(z=0)
+
+    ff_10m = wind.speed(u_10m, v_10m)
+    dd_10m = wind.direction(u_10m, v_10m)
+
+    conf_files = {
+        "inputi": data_dir / f"{model_name.upper()}_lfff<DDHH>0000_000",
+        "output": "<HH>_outfile.nc",
+    }
+    root = "/oprusers/osm/opr.emme/data/ICON_INPUT"
+    icon_grid_description = {
+        "icon-ch1-eps": f"{root}/ICON-CH1-EPS/icon_grid_0001_R19B08_mch.nc",
+        "icon-ch2-eps": f"{root}/ICON-CH2-EPS/icon_grid_0002_R19B07_mch.nc",
+    }
+    fx_ds = fieldextra(
+        "wind_icon",
+        model_name=model_name,
+        icon_grid_description=icon_grid_description[model_name],
+        conf_files=conf_files,
+    )
+
+    assert_allclose(ff_10m, fx_ds["FF_10M"], rtol=1e-6)
 
     assert ff_10m.parameter == {
         "centre": "lssw",


### PR DESCRIPTION
## Purpose

Checks for a staggered grid where using origin_x and origin_y, which don't make sense for the ICON grid. Change these checks to first check if the data uses the ICON grid.

Does not:
* Update operators that require a regular grid for computations to be correct.
* Change checks for GRIB geography metadata, some of these may still break without a meaningful error

## Code changes:

- Add metadata.is_staggered and replace checks on origin_x and origin_y with calls to this function
- Add tests on new functions
- Add ICON grid test to test_wind.py

## Checklist
Before submitting this PR, please make sure:

- [x ] You have followed the coding standards guidelines established at [Code Review Checklist](https://meteoswiss.atlassian.net/wiki/spaces/UA/pages/20157433/Factory).
- [x ] Docstrings and type hints are added to new and updated routines, as appropriate
- [x ] All relevant documentation has been updated or added (e.g. README)
- [x ] Unit tests are added or updated for non-operator code
- [x ] New operators are properly tested

Additionally, if the PR updates the version of the package

- [ N/A] The new version is properly set
- [ N/A] A Tag will be created after the bump

## Review
For the review process follow the guidelines at [Checklist](https://meteoswiss.atlassian.net/wiki/spaces/UA/pages/20156488/Code+Review)
