### PR TITLE
Set GRIB metadata for UTM grids. Otherwise set geography to "does not apply"

### DIFF
--- a/src/meteodatalab/operators/regrid.py
+++ b/src/meteodatalab/operators/regrid.py
@@ -34,7 +34,7 @@ CRS_ALIASES = {
     "swiss95": "epsg:2056",  # Swiss CH1903+ / LV95
     "boaga-west": "epsg:3003",  # Monte Mario / Italy zone 1
     "boaga-east": "epsg:3004",  # Monte Mario / Italy zone 2
-    "utm32": "epsg:32632",  # UTM 32N
+    "utm32n": "epsg:32632",  # Universal Transverse Mercator zone 32N
 }
 
 
@@ -130,9 +130,8 @@ class RegularGrid:
         nx = (xmax - xmin) / dx + 1
         ny = (ymax - ymin) / dy + 1
         if abs(nx - round(nx)) > 1e-10 or abs(ny - round(ny)) > 1e-10:
-            print(f"diff x: {abs(nx - round(nx))}, diff y: {abs(ny - round(ny))}")
             raise ValueError("Inconsistent regrid parameters")
-        return cls(crs, round(nx), round(ny), xmin, xmax, ymin, ymax)
+        return cls(crs, int(round(nx)), int(round(ny)), xmin, xmax, ymin, ymax)
 
     def to_crs(self, crs: str, **kwargs):
         """Return a new grid in the given coordinate reference system.
@@ -207,7 +206,7 @@ def _lon_from_utm_zone(zone: int) -> int:
     return offset - 183
 
 
-def _grib_utm_m(value: float) -> int:
+def _grib_utm_m(value: float | int) -> int:
     # For UTM units, GRIB2 uses 10-2m whereas CRS uses m.
     return int(round(100 * value))
 

--- a/src/meteodatalab/operators/regrid.py
+++ b/src/meteodatalab/operators/regrid.py
@@ -250,6 +250,16 @@ def _get_metadata(grid: RegularGrid):
             "longitudeOfSouthernPole": _udeg(grid.crs.get("lon_0")),
             "angleOfRotation": 0.0,
         }
+    else:
+        # Rather than attempt to populate the GRIB definition in the general case, we
+        # just set the sourceOfGridDefinition to 255. Ideally we would also set
+        # gridDefinitionTemplateNumber to 65535, but eccodes attempts and fails to find
+        # a template by this number.
+        return {
+            "sourceOfGridDefinition": 255,  # grid definition does not apply
+            "numberOfDataPoints": grid.nx * grid.ny,
+            "numberOfOctectsForNumberOfPoints": 0,
+        }
 
 
 def regrid(

--- a/src/meteodatalab/operators/regrid.py
+++ b/src/meteodatalab/operators/regrid.py
@@ -34,6 +34,7 @@ CRS_ALIASES = {
     "swiss95": "epsg:2056",  # Swiss CH1903+ / LV95
     "boaga-west": "epsg:3003",  # Monte Mario / Italy zone 1
     "boaga-east": "epsg:3004",  # Monte Mario / Italy zone 2
+    "utm32": "epsg:32632",  # UTM 32N
 }
 
 
@@ -128,9 +129,10 @@ class RegularGrid:
             raise ValueError("Inconsistent regrid parameters")
         nx = (xmax - xmin) / dx + 1
         ny = (ymax - ymin) / dy + 1
-        if nx != int(nx) or ny != int(ny):
+        if abs(nx - round(nx)) > 1e-10 or abs(ny - round(ny)) > 1e-10:
+            print(f"diff x: {abs(nx - round(nx))}, diff y: {abs(ny - round(ny))}")
             raise ValueError("Inconsistent regrid parameters")
-        return cls(crs, int(nx), int(ny), xmin, xmax, ymin, ymax)
+        return cls(crs, round(nx), round(ny), xmin, xmax, ymin, ymax)
 
     def to_crs(self, crs: str, **kwargs):
         """Return a new grid in the given coordinate reference system.
@@ -192,8 +194,22 @@ class RegularGrid:
         )
 
 
-def _udeg(value):
+def _udeg(value: float) -> int:
     return int(round(value * 1e6))
+
+
+def _lon_from_utm_zone(zone: int) -> int:
+    if zone is None or zone < 1 or zone > 60:
+        raise ValueError(f"Invalid value for UTM zone: {zone}.")
+
+    # UTM zone are 6 degrees wide numbered from 1 starting at -180 to -174 degrees.
+    offset = zone * 6
+    return offset - 183
+
+
+def _grib_utm_m(value: float) -> int:
+    # For UTM units, GRIB2 uses 10-2m whereas CRS uses m.
+    return int(round(100 * value))
 
 
 def _get_metadata(grid: RegularGrid):
@@ -221,6 +237,34 @@ def _get_metadata(grid: RegularGrid):
             "longitudeOfLastGridPoint": _udeg(grid.xmax),
             "iDirectionIncrement": _udeg(grid.dx),
             "jDirectionIncrement": _udeg(grid.dy),
+            "scanningMode": scanning_mode,
+        }
+    elif grid.crs.get("proj") == "utm" and not grid.crs.get("south"):
+        # Transverse Mercator in northern hemisphere.
+        # https://codes.ecmwf.int/grib/format/grib2/ctables/3/4/
+        scanning_mode = set_code_flag([2])  # positive y
+        # i, j direction increments given relative to defined grid.
+        resolution_components_flags = set_code_flag([3, 4, 5])
+        return {
+            "numberOfDataPoints": grid.nx * grid.ny,
+            "sourceOfGridDefinition": 0,  # defined by template number
+            "numberOfOctectsForNumberOfPoints": 0,
+            "interpretationOfNumberOfPoints": 0,
+            "gridDefinitionTemplateNumber": 12,  # UTM
+            "shapeOfTheEarth": 5,  # WGS 84
+            "Ni": grid.nx,
+            "Nj": grid.ny,
+            "falseEasting": _grib_utm_m(500000),
+            "falseNorthing": 0,  # Northern hemisphere
+            "scaleFactorAtReferencePoint": 0.9996,
+            "longitudeOfReferencePoint": _lon_from_utm_zone(grid.crs.get("zone")),
+            "Di": _grib_utm_m(grid.dx),
+            "Dj": _grib_utm_m(grid.dy),
+            "X1": _grib_utm_m(grid.xmin),
+            "X2": _grib_utm_m(grid.xmax),
+            "Y1": _grib_utm_m(grid.ymin),
+            "Y2": _grib_utm_m(grid.ymax),
+            "resolutionAndComponentFlags": resolution_components_flags,
             "scanningMode": scanning_mode,
         }
     elif grid.crs.get("proj") == "ob_tran":

--- a/tests/test_meteodatalab/test_regrid.py
+++ b/tests/test_meteodatalab/test_regrid.py
@@ -190,7 +190,7 @@ def test_icon2utm(data_dir, fieldextra, model_name, geo_coords):
     ds = grib_decoder.load(source, "T", geo_coords=geo_coords)
 
     # Use a small rectangular area around Bern
-    regrid_target = "utm32,376000,5197000,386000,5206000,1000,500"
+    regrid_target = "utm32n,376000,5197000,386000,5206000,1000,500"
     dst = regrid.RegularGrid.parse_regrid_operator(regrid_target)
     observed = regrid.iconremap(ds["T"], dst)
 

--- a/tests/test_meteodatalab/test_regrid.py
+++ b/tests/test_meteodatalab/test_regrid.py
@@ -182,6 +182,10 @@ def test_icon2swiss_small(data_dir, fieldextra, model_name, geo_coords):
     assert observed.sel(y=18, x=10).lon == pytest.approx(7.504410, 1e-5)
     assert observed.sel(y=18, x=10).lat == pytest.approx(47.032020, 1e-5)
 
+    # Verify that the metadata grid fields that we can override are correct.
+    assert observed.metadata["sourceOfGridDefinition"] == 255
+    assert observed.metadata["numberOfDataPoints"] == 19 * 11
+
 
 @pytest.mark.skip(reason="the byc method in fx is not optimised (>30min on icon-ch1)")
 @pytest.mark.data("iconremap")

--- a/tests/test_meteodatalab/test_regrid.py
+++ b/tests/test_meteodatalab/test_regrid.py
@@ -162,10 +162,10 @@ def test_icon2swiss_small(data_dir, fieldextra, model_name, geo_coords):
     assert_array_less(extreme_low, observed.values)
     assert_array_less(observed.values, extreme_high)
 
-    assert observed.y.shape == (19,)
-    assert observed.x.shape == (11,)
     # Verify that geolatlon coordinates match expected values on the corners and center.
     # Values are from https://epsg.io/transform#s_srs=21781&t_srs=4326
+    assert observed.y.shape == (19,)
+    assert observed.x.shape == (11,)
     assert observed.sel(y=9, x=5).lon == pytest.approx(7.438632, 1e-5)
     assert observed.sel(y=9, x=5).lat == pytest.approx(46.951082, 1e-5)
     assert observed.sel(y=0, x=0).lon == pytest.approx(7.373052, 1e-5)
@@ -180,6 +180,50 @@ def test_icon2swiss_small(data_dir, fieldextra, model_name, geo_coords):
     # Verify that the metadata grid fields that we can override are correct.
     assert observed.metadata["sourceOfGridDefinition"] == 255
     assert observed.metadata["numberOfDataPoints"] == 19 * 11
+
+
+@pytest.mark.data("iconremap")
+@pytest.mark.parametrize("model_name", ["icon-ch1-eps", "icon-ch2-eps"])
+def test_icon2utm(data_dir, fieldextra, model_name, geo_coords):
+    datafiles = [str(data_dir / f"{model_name.upper()}_lfff00000000_000")]
+    source = data_source.FileDataSource(datafiles=datafiles)
+    ds = grib_decoder.load(source, "T", geo_coords=geo_coords)
+
+    # Use a small rectangular area around Bern
+    regrid_target = "utm32,376000,5197000,386000,5206000,1000,500"
+    dst = regrid.RegularGrid.parse_regrid_operator(regrid_target)
+    observed = regrid.iconremap(ds["T"], dst)
+
+    # Sanity check the temperature values.
+    extreme_low = np.full(observed.shape, 150)
+    extreme_high = np.full(observed.shape, 350)
+    assert_array_less(extreme_low, observed.values)
+    assert_array_less(observed.values, extreme_high)
+
+    # Verify that geolatlon coordinates match expected values on the corners and center.
+    # Values are from https://epsg.io/transform#s_srs=32632&t_srs=4326
+    assert observed.y.shape == (19,)
+    assert observed.x.shape == (11,)
+    assert observed.sel(y=9, x=5).lon == pytest.approx(7.435998, 1e-5)
+    assert observed.sel(y=9, x=5).lat == pytest.approx(46.956345, 1e-5)
+    assert observed.sel(y=0, x=0).lon == pytest.approx(7.3715379, 1e-5)
+    assert observed.sel(y=0, x=0).lat == pytest.approx(46.9149497, 1e-5)
+    assert observed.sel(y=18, x=0).lon == pytest.approx(7.36908, 1e-5)
+    assert observed.sel(y=18, x=0).lat == pytest.approx(46.995906, 1e-5)
+    assert observed.sel(y=0, x=10).lon == pytest.approx(7.502818, 1e-5)
+    assert observed.sel(y=0, x=10).lat == pytest.approx(46.916742, 1e-5)
+    assert observed.sel(y=18, x=10).lon == pytest.approx(7.500557, 1e-5)
+    assert observed.sel(y=18, x=10).lat == pytest.approx(46.997704, 1e-5)
+
+    # Verify the geography is set correctly.
+    assert observed.metadata["sourceOfGridDefinition"] == 0
+    assert observed.metadata["numberOfDataPoints"] == 19 * 11
+    assert observed.metadata["gridDefinitionTemplateNumber"] == 12
+    assert observed.metadata["longitudeOfReferencePoint"] == 9.0
+    assert observed.metadata["iDirectionIncrementGridLength"] == 100000
+    assert observed.metadata["jDirectionIncrementGridLength"] == 50000
+    assert observed.metadata["X1"] == 37600000
+    assert observed.metadata["Y2"] == 520600000
 
 
 @pytest.mark.skip(reason="the byc method in fx is not optimised (>30min on icon-ch1)")


### PR DESCRIPTION
## Purpose

When regridding from ICON, add GRIB geography support for UTM grids in northern hemisphere and add a default case that sets the grid definition to "does not apply". The current behaviour leaves the definition the same, which puts the xarray in an inconsistent state.

For our data, UTM zone 32N is the most sensible, but we set the longitude offset for any UTM grid.

## Code changes:

- Adds branches to regrid._get_metadata and supporting functions with tests

