### PR TITLE
Use eccodes cosmo resources python

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -21,10 +21,10 @@ pipeline {
                 sh '''#!/usr/bin/env bash
                 set -e
                 spack_c2sm_url=https://github.com/C2SM/spack-c2sm.git
-                spack_c2sm_tag=v0.20.1.9
+                spack_c2sm_tag=v0.22.2.2
                 spack_c2sm_dir=${WORKSPACE}/s
                 git clone --depth 1 --recurse-submodules -b ${spack_c2sm_tag} ${spack_c2sm_url} ${spack_c2sm_dir}
-                . ${spack_c2sm_dir}/setup-env.sh
+                . ${spack_c2sm_dir}/setup-env.sh /mch-environment/v8
                 spack env activate -p ${WORKSPACE}/spack-env
                 spack mirror add iwf2-mirror /store_new/mch/msopr/icon_workflow_2/spack-mirror
                 spack install --no-check-signature --no-checksum

--- a/poetry.lock
+++ b/poetry.lock
@@ -749,13 +749,13 @@ numpy = "*"
 
 [[package]]
 name = "eccodes-cosmo-resources-python"
-version = "2.36.0.3"
+version = "2.36.0.3.post0"
 description = ""
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "eccodes_cosmo_resources_python-2.36.0.3-py3-none-any.whl", hash = "sha256:7c2b799ed6a84c9c891c1c84210c0cca4e328df80846d8492a86a2166442e53d"},
-    {file = "eccodes_cosmo_resources_python-2.36.0.3.tar.gz", hash = "sha256:5cad10f4c46c437f958319de7b508b42ca3be536949420b982dd8ff454757f34"},
+    {file = "eccodes_cosmo_resources_python-2.36.0.3.post0-py3-none-any.whl", hash = "sha256:570516b36ef35a6398133abf1fa86ee86b7cc78e61a36d2b257e898786934214"},
+    {file = "eccodes_cosmo_resources_python-2.36.0.3.post0.tar.gz", hash = "sha256:906298242fc718675a42c900eeeef0676a65f6c78a1ee11fba4a89682a43020f"},
 ]
 
 [[package]]
@@ -2167,13 +2167,13 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pyparsing"
-version = "3.2.1"
+version = "3.2.2"
 description = "pyparsing module - Classes and methods to define and execute parsing grammars"
 optional = true
 python-versions = ">=3.9"
 files = [
-    {file = "pyparsing-3.2.1-py3-none-any.whl", hash = "sha256:506ff4f4386c4cec0590ec19e6302d3aedb992fdc02c761e90416f158dacf8e1"},
-    {file = "pyparsing-3.2.1.tar.gz", hash = "sha256:61980854fd66de3a90028d679a954d5f2623e83144b5afe5ee86f43d762e5f0a"},
+    {file = "pyparsing-3.2.2-py3-none-any.whl", hash = "sha256:6ab05e1cb111cc72acc8ed811a3ca4c2be2af8d7b6df324347f04fd057d8d793"},
+    {file = "pyparsing-3.2.2.tar.gz", hash = "sha256:2a857aee851f113c2de9d4bfd9061baea478cb0f1c7ca6cbf594942d6d111575"},
 ]
 
 [package.extras]
@@ -3140,13 +3140,13 @@ files = [
 
 [[package]]
 name = "tzdata"
-version = "2025.1"
+version = "2025.2"
 description = "Provider of IANA time zone data"
 optional = false
 python-versions = ">=2"
 files = [
-    {file = "tzdata-2025.1-py2.py3-none-any.whl", hash = "sha256:7e127113816800496f027041c570f50bcd464a020098a3b6b199517772303639"},
-    {file = "tzdata-2025.1.tar.gz", hash = "sha256:24894909e88cdb28bd1636c6887801df64cb485bd593f2fd83ef29075a81d694"},
+    {file = "tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8"},
+    {file = "tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9"},
 ]
 
 [[package]]

--- a/poetry.lock
+++ b/poetry.lock
@@ -50,13 +50,13 @@ files = [
 
 [[package]]
 name = "array-api-compat"
-version = "1.11.1"
+version = "1.11.2"
 description = "A wrapper around NumPy and other array libraries to make them compatible with the Array API standard"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "array_api_compat-1.11.1-py3-none-any.whl", hash = "sha256:cf5efc8e171a65694c8d316223edebc22161dce052e994c21a9cbb4deb3d056b"},
-    {file = "array_api_compat-1.11.1.tar.gz", hash = "sha256:9d80383f5a52a3adb09c3e0a062b0be168761e4b8d7079cfea1f7387fc2eae63"},
+    {file = "array_api_compat-1.11.2-py3-none-any.whl", hash = "sha256:b1d0059714a4153b3ae37c989e47b07418f727be5b22908dd3cf9d19bdc2c547"},
+    {file = "array_api_compat-1.11.2.tar.gz", hash = "sha256:a3b7f7b6af18f4c42e79423b1b2479798998b6a74355069d77a01a5282755b5d"},
 ]
 
 [package.extras]
@@ -663,13 +663,13 @@ files = [
 
 [[package]]
 name = "earthkit-data"
-version = "0.13.3"
+version = "0.13.4"
 description = "A format-agnostic Python interface for geospatial data"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "earthkit_data-0.13.3-py3-none-any.whl", hash = "sha256:4eb6b245ca544f2b2ed6c63d4317b48beec549be4e3d33aa72c839b5381cc1ed"},
-    {file = "earthkit_data-0.13.3.tar.gz", hash = "sha256:4d5fa454ec39716cee9fce828df8d41d75f6ee4ed1b5a7a28dacce7636374d8e"},
+    {file = "earthkit_data-0.13.4-py3-none-any.whl", hash = "sha256:0bf8db177ec1b11d9dd4b9521f538eae357cbcf6c8af82da63dad009927dc676"},
+    {file = "earthkit_data-0.13.4.tar.gz", hash = "sha256:adac40f82bcfc899c3b55bd64f8bbd2dd2e510487a9d24b9932531999f7c2fe5"},
 ]
 
 [package.dependencies]
@@ -746,6 +746,17 @@ attrs = "*"
 cffi = "*"
 findlibs = "*"
 numpy = "*"
+
+[[package]]
+name = "eccodes-cosmo-resources-python"
+version = "2.36.0.3"
+description = ""
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "eccodes_cosmo_resources_python-2.36.0.3-py3-none-any.whl", hash = "sha256:7c2b799ed6a84c9c891c1c84210c0cca4e328df80846d8492a86a2166442e53d"},
+    {file = "eccodes_cosmo_resources_python-2.36.0.3.tar.gz", hash = "sha256:5cad10f4c46c437f958319de7b508b42ca3be536949420b982dd8ff454757f34"},
+]
 
 [[package]]
 name = "entrypoints"
@@ -952,13 +963,13 @@ type = ["pytest-mypy"]
 
 [[package]]
 name = "iniconfig"
-version = "2.0.0"
+version = "2.1.0"
 description = "brain-dead simple config-ini parsing"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
-    {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
+    {file = "iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"},
+    {file = "iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"},
 ]
 
 [[package]]
@@ -1414,12 +1425,13 @@ files = [
 
 [[package]]
 name = "multiurl"
-version = "0.3.3"
+version = "0.3.5"
 description = "A package to download several URL as one, as well as supporting multi-part URLs"
 optional = false
 python-versions = "*"
 files = [
-    {file = "multiurl-0.3.3.tar.gz", hash = "sha256:f4d0b69dcf4a0ed740daa313dbcd4d5665420d305c50ca879285e96dc828093f"},
+    {file = "multiurl-0.3.5-py3-none-any.whl", hash = "sha256:37b920c3116861198ec5b24080fed5344514006021eec969784dabc76fcf3d63"},
+    {file = "multiurl-0.3.5.tar.gz", hash = "sha256:c2fb8b85227caa453fa0c9e711c5a83e3fd6d9a30b5010ce8a8a4e872d31211e"},
 ]
 
 [package.dependencies]
@@ -1797,19 +1809,19 @@ ptyprocess = ">=0.5"
 
 [[package]]
 name = "platformdirs"
-version = "4.3.6"
+version = "4.3.7"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb"},
-    {file = "platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907"},
+    {file = "platformdirs-4.3.7-py3-none-any.whl", hash = "sha256:a03875334331946f13c549dbd8f4bac7a13a50a895a0eb1e8c6a8ace80d40a94"},
+    {file = "platformdirs-4.3.7.tar.gz", hash = "sha256:eb437d586b6a0986388f0d6f74aa0cde27b48d0e3d66843640bfb6bdcdb6e351"},
 ]
 
 [package.extras]
-docs = ["furo (>=2024.8.6)", "proselint (>=0.14)", "sphinx (>=8.0.2)", "sphinx-autodoc-typehints (>=2.4)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.3.2)", "pytest-cov (>=5)", "pytest-mock (>=3.14)"]
-type = ["mypy (>=1.11.2)"]
+docs = ["furo (>=2024.8.6)", "proselint (>=0.14)", "sphinx (>=8.1.3)", "sphinx-autodoc-typehints (>=3)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.3.4)", "pytest-cov (>=6)", "pytest-mock (>=3.14)"]
+type = ["mypy (>=1.14.1)"]
 
 [[package]]
 name = "pluggy"
@@ -1847,13 +1859,13 @@ tqdm = "*"
 
 [[package]]
 name = "pre-commit"
-version = "4.1.0"
+version = "4.2.0"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "pre_commit-4.1.0-py2.py3-none-any.whl", hash = "sha256:d29e7cb346295bcc1cc75fc3e92e343495e3ea0196c9ec6ba53f49f10ab6ae7b"},
-    {file = "pre_commit-4.1.0.tar.gz", hash = "sha256:ae3f018575a588e30dfddfab9a05448bfbd6b73d78709617b5a2b853549716d4"},
+    {file = "pre_commit-4.2.0-py2.py3-none-any.whl", hash = "sha256:a009ca7205f1eb497d10b845e52c838a98b6cdd2102a6c8e4540e94ee75c58bd"},
+    {file = "pre_commit-4.2.0.tar.gz", hash = "sha256:601283b9757afd87d40c4c4a9b2b5de9637a8ea02eaff7adc2d0fb4e04841146"},
 ]
 
 [package.dependencies]
@@ -2255,27 +2267,27 @@ files = [
 
 [[package]]
 name = "pywin32"
-version = "309"
+version = "310"
 description = "Python for Window Extensions"
 optional = false
 python-versions = "*"
 files = [
-    {file = "pywin32-309-cp310-cp310-win32.whl", hash = "sha256:5b78d98550ca093a6fe7ab6d71733fbc886e2af9d4876d935e7f6e1cd6577ac9"},
-    {file = "pywin32-309-cp310-cp310-win_amd64.whl", hash = "sha256:728d08046f3d65b90d4c77f71b6fbb551699e2005cc31bbffd1febd6a08aa698"},
-    {file = "pywin32-309-cp310-cp310-win_arm64.whl", hash = "sha256:c667bcc0a1e6acaca8984eb3e2b6e42696fc035015f99ff8bc6c3db4c09a466a"},
-    {file = "pywin32-309-cp311-cp311-win32.whl", hash = "sha256:d5df6faa32b868baf9ade7c9b25337fa5eced28eb1ab89082c8dae9c48e4cd51"},
-    {file = "pywin32-309-cp311-cp311-win_amd64.whl", hash = "sha256:e7ec2cef6df0926f8a89fd64959eba591a1eeaf0258082065f7bdbe2121228db"},
-    {file = "pywin32-309-cp311-cp311-win_arm64.whl", hash = "sha256:54ee296f6d11db1627216e9b4d4c3231856ed2d9f194c82f26c6cb5650163f4c"},
-    {file = "pywin32-309-cp312-cp312-win32.whl", hash = "sha256:de9acacced5fa82f557298b1fed5fef7bd49beee04190f68e1e4783fbdc19926"},
-    {file = "pywin32-309-cp312-cp312-win_amd64.whl", hash = "sha256:6ff9eebb77ffc3d59812c68db33c0a7817e1337e3537859499bd27586330fc9e"},
-    {file = "pywin32-309-cp312-cp312-win_arm64.whl", hash = "sha256:619f3e0a327b5418d833f44dc87859523635cf339f86071cc65a13c07be3110f"},
-    {file = "pywin32-309-cp313-cp313-win32.whl", hash = "sha256:008bffd4afd6de8ca46c6486085414cc898263a21a63c7f860d54c9d02b45c8d"},
-    {file = "pywin32-309-cp313-cp313-win_amd64.whl", hash = "sha256:bd0724f58492db4cbfbeb1fcd606495205aa119370c0ddc4f70e5771a3ab768d"},
-    {file = "pywin32-309-cp313-cp313-win_arm64.whl", hash = "sha256:8fd9669cfd41863b688a1bc9b1d4d2d76fd4ba2128be50a70b0ea66b8d37953b"},
-    {file = "pywin32-309-cp38-cp38-win32.whl", hash = "sha256:617b837dc5d9dfa7e156dbfa7d3906c009a2881849a80a9ae7519f3dd8c6cb86"},
-    {file = "pywin32-309-cp38-cp38-win_amd64.whl", hash = "sha256:0be3071f555480fbfd86a816a1a773880ee655bf186aa2931860dbb44e8424f8"},
-    {file = "pywin32-309-cp39-cp39-win32.whl", hash = "sha256:72ae9ae3a7a6473223589a1621f9001fe802d59ed227fd6a8503c9af67c1d5f4"},
-    {file = "pywin32-309-cp39-cp39-win_amd64.whl", hash = "sha256:88bc06d6a9feac70783de64089324568ecbc65866e2ab318eab35da3811fd7ef"},
+    {file = "pywin32-310-cp310-cp310-win32.whl", hash = "sha256:6dd97011efc8bf51d6793a82292419eba2c71cf8e7250cfac03bba284454abc1"},
+    {file = "pywin32-310-cp310-cp310-win_amd64.whl", hash = "sha256:c3e78706e4229b915a0821941a84e7ef420bf2b77e08c9dae3c76fd03fd2ae3d"},
+    {file = "pywin32-310-cp310-cp310-win_arm64.whl", hash = "sha256:33babed0cf0c92a6f94cc6cc13546ab24ee13e3e800e61ed87609ab91e4c8213"},
+    {file = "pywin32-310-cp311-cp311-win32.whl", hash = "sha256:1e765f9564e83011a63321bb9d27ec456a0ed90d3732c4b2e312b855365ed8bd"},
+    {file = "pywin32-310-cp311-cp311-win_amd64.whl", hash = "sha256:126298077a9d7c95c53823934f000599f66ec9296b09167810eb24875f32689c"},
+    {file = "pywin32-310-cp311-cp311-win_arm64.whl", hash = "sha256:19ec5fc9b1d51c4350be7bb00760ffce46e6c95eaf2f0b2f1150657b1a43c582"},
+    {file = "pywin32-310-cp312-cp312-win32.whl", hash = "sha256:8a75a5cc3893e83a108c05d82198880704c44bbaee4d06e442e471d3c9ea4f3d"},
+    {file = "pywin32-310-cp312-cp312-win_amd64.whl", hash = "sha256:bf5c397c9a9a19a6f62f3fb821fbf36cac08f03770056711f765ec1503972060"},
+    {file = "pywin32-310-cp312-cp312-win_arm64.whl", hash = "sha256:2349cc906eae872d0663d4d6290d13b90621eaf78964bb1578632ff20e152966"},
+    {file = "pywin32-310-cp313-cp313-win32.whl", hash = "sha256:5d241a659c496ada3253cd01cfaa779b048e90ce4b2b38cd44168ad555ce74ab"},
+    {file = "pywin32-310-cp313-cp313-win_amd64.whl", hash = "sha256:667827eb3a90208ddbdcc9e860c81bde63a135710e21e4cb3348968e4bd5249e"},
+    {file = "pywin32-310-cp313-cp313-win_arm64.whl", hash = "sha256:e308f831de771482b7cf692a1f308f8fca701b2d8f9dde6cc440c7da17e47b33"},
+    {file = "pywin32-310-cp38-cp38-win32.whl", hash = "sha256:0867beb8addefa2e3979d4084352e4ac6e991ca45373390775f7084cc0209b9c"},
+    {file = "pywin32-310-cp38-cp38-win_amd64.whl", hash = "sha256:30f0a9b3138fb5e07eb4973b7077e1883f558e40c578c6925acc7a94c34eaa36"},
+    {file = "pywin32-310-cp39-cp39-win32.whl", hash = "sha256:851c8d927af0d879221e616ae1f66145253537bbdd321a77e8ef701b443a9a1a"},
+    {file = "pywin32-310-cp39-cp39-win_amd64.whl", hash = "sha256:96867217335559ac619f00ad70e513c0fcf84b8a3af9fc2bba3b59b97da70475"},
 ]
 
 [[package]]
@@ -2754,18 +2766,18 @@ test = ["array-api-strict", "asv", "gmpy2", "hypothesis (>=6.30)", "mpmath", "po
 
 [[package]]
 name = "setuptools"
-version = "76.0.0"
+version = "77.0.3"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "setuptools-76.0.0-py3-none-any.whl", hash = "sha256:199466a166ff664970d0ee145839f5582cb9bca7a0a3a2e795b6a9cb2308e9c6"},
-    {file = "setuptools-76.0.0.tar.gz", hash = "sha256:43b4ee60e10b0d0ee98ad11918e114c70701bc6051662a9a675a0496c1a158f4"},
+    {file = "setuptools-77.0.3-py3-none-any.whl", hash = "sha256:67122e78221da5cf550ddd04cf8742c8fe12094483749a792d56cd669d6cf58c"},
+    {file = "setuptools-77.0.3.tar.gz", hash = "sha256:583b361c8da8de57403743e756609670de6fb2345920e36dc5c2d914c319c945"},
 ]
 
 [package.extras]
 check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)", "ruff (>=0.8.0)"]
-core = ["importlib_metadata (>=6)", "jaraco.collections", "jaraco.functools (>=4)", "jaraco.text (>=3.7)", "more_itertools", "more_itertools (>=8.8)", "packaging", "packaging (>=24.2)", "platformdirs (>=4.2.2)", "tomli (>=2.0.1)", "wheel (>=0.43.0)"]
+core = ["importlib_metadata (>=6)", "jaraco.functools (>=4)", "jaraco.text (>=3.7)", "more_itertools", "more_itertools (>=8.8)", "packaging (>=24.2)", "platformdirs (>=4.2.2)", "tomli (>=2.0.1)", "wheel (>=0.43.0)"]
 cover = ["pytest-cov"]
 doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
 enabler = ["pytest-enabler (>=2.2)"]
@@ -3081,13 +3093,13 @@ typing-extensions = ">=3.7.4.3"
 
 [[package]]
 name = "types-pytz"
-version = "2025.1.0.20250204"
+version = "2025.1.0.20250318"
 description = "Typing stubs for pytz"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "types_pytz-2025.1.0.20250204-py3-none-any.whl", hash = "sha256:32ca4a35430e8b94f6603b35beb7f56c32260ddddd4f4bb305fdf8f92358b87e"},
-    {file = "types_pytz-2025.1.0.20250204.tar.gz", hash = "sha256:00f750132769f1c65a4f7240bc84f13985b4da774bd17dfbe5d9cd442746bd49"},
+    {file = "types_pytz-2025.1.0.20250318-py3-none-any.whl", hash = "sha256:04dba4907c5415777083f9548693c6d9f80ec53adcaff55a38526a3f8ddcae04"},
+    {file = "types_pytz-2025.1.0.20250318.tar.gz", hash = "sha256:97e0e35184c6fe14e3a5014512057f2c57bb0c6582d63c1cfcc4809f82180449"},
 ]
 
 [[package]]
@@ -3236,4 +3248,4 @@ regrid = ["pyproj", "rasterio", "scipy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "2b075204f93a63eebccc0bebdf2e65613068c8977e683b18644cad570335159f"
+content-hash = "51d762701fc72d63aa9f9f8fa3e6a886d269b6bceed429a2eb747b900edae0d1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ python = ">=3.9,<3.13"
 click = "^8.1.7"
 earthkit-data = ">=0.5.6,<1"
 eccodes = "^1.5.0"
+eccodes-cosmo-resources-python = "==2.36.*"
 numpy = "^1.26.4"
 polytope-client = { version = "^0.7.4", optional = true}
 pydantic = "*"

--- a/spack-env/spack.yaml
+++ b/spack-env/spack.yaml
@@ -4,10 +4,10 @@
 # configuration settings.
 spack:
   specs:
-  - fdb@=5.11.126 +tools
-  - eckit@=1.26.3 ~mpi
-  - eccodes@=2.35.0 jp2k=none
-  - metkit@=1.11.14
+  - fdb@=5.15.11 +tools
+  - eckit@=1.28.5
+  - eccodes@2.36.4
+  - metkit@=1.11.22
   view: true
   concretizer:
     unify: true

--- a/src/meteodatalab/data_source.py
+++ b/src/meteodatalab/data_source.py
@@ -3,7 +3,6 @@
 # Standard library
 import dataclasses as dc
 import os
-import sys
 import typing
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
@@ -15,6 +14,7 @@ from pathlib import Path
 # Third-party
 import earthkit.data as ekd  # type: ignore
 import eccodes  # type: ignore
+import eccodes_cosmo_resources
 
 try:
     # Third-party
@@ -37,9 +37,8 @@ def cosmo_grib_defs():
 
     token = definitions.set("cosmo")
     restore = eccodes.codes_definition_path()
-    root_dir = Path(sys.prefix) / "share"
     paths = (
-        root_dir / "eccodes-cosmo-resources/definitions",
+        eccodes_cosmo_resources.get_definitions_path(),
         Path(restore),
     )
     for path in paths:

--- a/tools/setup_poetry.sh
+++ b/tools/setup_poetry.sh
@@ -4,8 +4,8 @@ poetry_version="1.8.1"
 prefix=$(pwd)/poetry-${poetry_version}
 
 if grep -q balfrin /etc/xthostname; then
-    module use /mch-environment/v6/modules/
-    module load python/3.10.8
+    module use /mch-environment/v8/modules/
+    module load python/3.11.7
 fi
 
 if [ ! -d "${prefix}" ]; then
@@ -16,14 +16,8 @@ fi
 
 if [ -d ${HOME}/.local/bin ]; then
     echo "Updating symlink at ${HOME}/.local/bin/poetry"
-    ln -sf ${poetry} ${HOME}/.local/bin/poetry
+    ln -sf ${prefix}/bin/poetry ${HOME}/.local/bin/poetry
 fi
 
 ${prefix}/bin/poetry config --list
 ${prefix}/bin/poetry install -vv --sync --all-extras
-
-venv=$(${prefix}/bin/poetry run python -c "import sys; print(sys.prefix)")
-cosmo_resources=${venv}/share/eccodes-cosmo-resources
-if [ ! -d "${cosmo_resources}" ]; then
-    git clone --depth 1 --branch v2.35.0.1dm1 https://github.com/COSMO-ORG/eccodes-cosmo-resources.git $cosmo_resources
-fi


### PR DESCRIPTION
## Purpose

Use the eccodes cosmo resources definitions that are distributed as a python package

## Code changes:

- Mars definitions for eccodes are no longer available. These should be installed separately to use the FDB archival function.

## Requirements changes:

- Added eccodes-cosmo-resources-python
- Upgraded to eccodes 2.36

## Infrastructure changes:

- spack-c2sm updated to v0.22.2.2
- change to the mch environment v8


