### PR TITLE
OG-46: Fetch grid metadata via STAC API and avoid redundant downloads

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,15 @@
 # History
 
+## [0.2.1a1] (2025-04-03)
+
+### Additions
+- `ogd_api`:
+  - Added `get_collection_asset_url` function to fetch pre-signed URLs for static assets from a STAC collection.
+
+### Breaking Changes
+- The `geo_coords_urls.yaml` file containing pre-signed URLs for coordinate files has been removed. Coordinate URLs are now resolved dynamically using the new get_collection_asset_url function.
+
+
 ## [0.2.0] (2025-03-20)
 
 ### Additions

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 # History
 
-## [0.2.1a1] (2025-04-03)
+## [unreleased] (2025-04-03)
 
 ### Additions
 - `ogd_api`:
@@ -109,6 +109,7 @@
 - Added ninjo_k2th product
 - Added GRIB data loader based on earthkit-data
 
+[unreleased]: https://github.com/MeteoSwiss/meteodata-lab/compare/v0.2.0..main
 [0.2.0]: https://github.com/MeteoSwiss/meteodata-lab/compare/v0.2.0-rc3..v0.2.0
 [0.2.0-rc3]: https://github.com/MeteoSwiss-APN/icon_data_processing_incubator/compare/v0.2.0-rc2..v0.2.0-rc3
 [0.2.0-rc2]: https://github.com/MeteoSwiss-APN/icon_data_processing_incubator/compare/v0.2.0-rc1..v0.2.0-rc2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "meteodata-lab"
-version = "0.2.1a"
+version = "0.2.1a1"
 description = "A data post-processing framework on the basis of xarray."
 readme = "README.md"
 keywords = ["Icon", "Data Processing"]

--- a/src/meteodatalab/data/geo_coords_urls.yaml
+++ b/src/meteodatalab/data/geo_coords_urls.yaml
@@ -1,6 +1,0 @@
-icon-ch1-eps:
-  vertical: https://rgw.cscs.ch/cscs.meteoswiss.ogd.nwp.static/vertical_constants_ICON-CH1-EPS.grib2?AWSAccessKeyId=13GC1T4NT2CY1N0L92YC&Signature=iJcbSbcxhg9D1fa4QY6q0tI2dIQ%3D&Expires=1744787114
-  horizontal: https://rgw.cscs.ch/cscs.meteoswiss.ogd.nwp.static/horizontal_constants_ICON-CH1-EPS.grib2?AWSAccessKeyId=13GC1T4NT2CY1N0L92YC&Signature=UGsmyVq7GDG014nkMT2KHEis09o%3D&Expires=1744787111
-icon-ch2-eps:
-  vertical: https://rgw.cscs.ch/cscs.meteoswiss.ogd.nwp.static/vertical_constants_ICON-CH2-EPS.grib2?AWSAccessKeyId=13GC1T4NT2CY1N0L92YC&Signature=OOS5%2BcuRNre8qTRBgqK5Vf29BuU%3D&Expires=1744786857
-  horizontal: https://rgw.cscs.ch/cscs.meteoswiss.ogd.nwp.static/horizontal_constants_ICON-CH2-EPS.grib2?AWSAccessKeyId=13GC1T4NT2CY1N0L92YC&Signature=qbZhFGwKFFP%2Bo5ScS%2FMW4H1IvWI%3D&Expires=1744786856

--- a/src/meteodatalab/ogd_api.py
+++ b/src/meteodatalab/ogd_api.py
@@ -300,6 +300,10 @@ def _download_with_checksum(url: str, target: Path) -> None:
     filename = Path(urlparse(url).path).name
     path = target / filename if target.is_dir() else target
 
+    if path.exists():
+        logger.info(f"File already exists, skipping download: {path}")
+        return
+
     hasher = hashlib.sha256()
     with path.open("wb") as f:
         for chunk in response.iter_content(16 * 1024):

--- a/src/meteodatalab/ogd_api.py
+++ b/src/meteodatalab/ogd_api.py
@@ -8,7 +8,6 @@ import hashlib
 import logging
 import os
 import typing
-from importlib.resources import files
 from pathlib import Path
 from urllib.parse import urlparse
 from uuid import UUID
@@ -18,7 +17,6 @@ import earthkit.data as ekd  # type: ignore
 import pydantic
 import pydantic.dataclasses as pdc
 import xarray as xr
-import yaml
 
 # Local
 from . import data_source, grib_decoder, icon_grid, util
@@ -153,7 +151,8 @@ def get_asset_url(request: Request):
 
     return asset_url
 
-def get_collection_asset_url(collection_id: str, asset_id:str) -> str:
+
+def get_collection_asset_url(collection_id: str, asset_id: str) -> str:
     """Get collection asset URL from OGD.
 
     Query the STAC collection assets and return the URL for the given asset ID.
@@ -161,9 +160,9 @@ def get_collection_asset_url(collection_id: str, asset_id:str) -> str:
     Parameters
     ----------
     collection_id : str
-        Full STAC collection ID, e.g., 'ch.meteoschweiz.ogd-forecasting-icon-ch1'.
+        Full STAC collection ID
     asset_id : str
-        The ID of the static asset to retrieve, e.g., 'horizontal_constants_icon-ch1-eps.grib2'.
+        The ID of the static asset to retrieve.
 
     Returns
     -------
@@ -174,6 +173,7 @@ def get_collection_asset_url(collection_id: str, asset_id:str) -> str:
     ------
     ValueError
         If the asset is not found in the collection.
+
     """
     url = f"{SEARCH_URL}/{collection_id}/assets"
 
@@ -184,7 +184,9 @@ def get_collection_asset_url(collection_id: str, asset_id:str) -> str:
     asset_info = assets.get(asset_id)
 
     if not asset_info or "href" not in asset_info:
-        raise ValueError(f"Asset '{asset_id}' not found in collection '{collection_id}'.")
+        raise ValueError(
+            f"Asset '{asset_id}' not found in collection '{collection_id}'."
+        )
 
     return asset_info["href"]
 

--- a/src/meteodatalab/ogd_api.py
+++ b/src/meteodatalab/ogd_api.py
@@ -171,7 +171,7 @@ def get_collection_asset_url(collection_id: str, asset_id: str) -> str:
 
     Raises
     ------
-    ValueError
+    KeyError
         If the asset is not found in the collection.
 
     """
@@ -184,9 +184,7 @@ def get_collection_asset_url(collection_id: str, asset_id: str) -> str:
     asset_info = assets.get(asset_id)
 
     if not asset_info or "href" not in asset_info:
-        raise ValueError(
-            f"Asset '{asset_id}' not found in collection '{collection_id}'."
-        )
+        raise KeyError(f"Asset '{asset_id}' not found in collection '{collection_id}'.")
 
     return asset_info["href"]
 
@@ -262,7 +260,7 @@ def download_from_ogd(request: Request, target: Path) -> None:
 
     In addition to the main asset, this function downloads static files
     with horizontal and vertical coordinates, as the forecast item
-    contain no height, longitude, or latitude information.
+    does not include the horizontal or vertical coordinates.
 
     Parameters
     ----------
@@ -285,12 +283,12 @@ def download_from_ogd(request: Request, target: Path) -> None:
     asset_url = get_asset_url(request)
     _download_with_checksum(asset_url, target)
 
-    model_suffix = request.collection.value.removeprefix("ogd-forecasting-")
-    collection_id = f"ch.meteoschweiz.{request.collection.value}"
+    model_suffix = request.collection.removeprefix("ogd-forecasting-")
+    collection_id = f"ch.meteoschweiz.{request.collection}"
 
     # Download coordinate files
     for prefix in ["horizontal", "vertical"]:
-        asset_id = f"{prefix}_constants_icon-{model_suffix}-eps.grib2"
+        asset_id = f"{prefix}_constants_{model_suffix}-eps.grib2"
         url = get_collection_asset_url(collection_id, asset_id)
         _download_with_checksum(url, target)
 

--- a/tests/test_meteodatalab/test_ogd_api.py
+++ b/tests/test_meteodatalab/test_ogd_api.py
@@ -8,6 +8,7 @@ from unittest import mock
 # Third-party
 import pydantic
 import pytest
+import requests
 import xarray as xr
 
 # First-party
@@ -110,44 +111,76 @@ def test_get_from_ogd(mock_session: mock.MagicMock, data_dir: Path):
 def test_download_from_ogd(
     mock_session: mock.MagicMock, tmp_path: Path, with_headers: bool
 ):
-    content = b"some content"
+    content_main = b"main content"
+    content_horizontal = b"horizontal content"
+    content_vertical = b"vertical content"
+
     main_href = "https://test.com/path/to/some-file.grib"
     horizontal_href = "https://test.com/path/to/horizontal.grib"
     vertical_href = "https://test.com/path/to/vertical.grib"
+
+    search_url = "https://sys-data.int.bgdi.ch/api/stac/v1/search"
+    collection_id = "ch.meteoschweiz.ogd-forecasting-icon-ch2"
+    assets_url = f"{search_url}/{collection_id}/assets"
 
     mock_post_response = mock.Mock()
     mock_post_response.json.return_value = {
         "features": [{"assets": {"some-asset.ext": {"href": main_href}}}],
         "links": [],
     }
-    mock_post_response.raise_for_status = mock.Mock()
 
     if with_headers:
-        headers = {"X-Amz-Meta-Sha256": hashlib.sha256(content).hexdigest()}
+        headers_main = {"X-Amz-Meta-Sha256": hashlib.sha256(content_main).hexdigest()}
+        headers_horizontal = {
+            "X-Amz-Meta-Sha256": hashlib.sha256(content_horizontal).hexdigest()
+        }
+        headers_vertical = {
+            "X-Amz-Meta-Sha256": hashlib.sha256(content_vertical).hexdigest()
+        }
     else:
-        headers = {}
+        headers_main = {}
+        headers_horizontal = {}
+        headers_vertical = {}
 
     def mock_get_response(url, *args, **kwargs):
         # Respond with asset list for coordinate URLs
-        if "assets" in url:
-            mock_resp = mock.Mock()
-            mock_resp.raise_for_status = mock.Mock()
-            mock_resp.json.return_value = {
-                "assets": {
-                    "horizontal_constants_icon-ch2-eps.grib2": {
-                        "href": horizontal_href
-                    },
-                    "vertical_constants_icon-ch2-eps.grib2": {"href": vertical_href},
-                }
-            }
-            return mock_resp
+        if url == assets_url:
+            return mock.Mock(
+                spec=requests.Response,
+                json=mock.Mock(
+                    return_value={
+                        "assets": {
+                            "horizontal_constants_icon-ch2-eps.grib2": {
+                                "href": horizontal_href
+                            },
+                            "vertical_constants_icon-ch2-eps.grib2": {
+                                "href": vertical_href
+                            },
+                        }
+                    }
+                ),
+            )
 
-        # Return mock file download
-        mock_resp = mock.Mock()
-        mock_resp.raise_for_status = mock.Mock()
-        mock_resp.iter_content.return_value = [content]
-        mock_resp.headers = headers
-        return mock_resp
+        if url == main_href:
+            return mock.Mock(
+                spec=requests.Response,
+                iter_content=mock.Mock(return_value=[content_main]),
+                headers=headers_main,
+            )
+        elif url == horizontal_href:
+            return mock.Mock(
+                spec=requests.Response,
+                iter_content=mock.Mock(return_value=[content_horizontal]),
+                headers=headers_horizontal,
+            )
+        elif url == vertical_href:
+            return mock.Mock(
+                spec=requests.Response,
+                iter_content=mock.Mock(return_value=[content_vertical]),
+                headers=headers_vertical,
+            )
+
+        raise ValueError(f"Unexpected URL: {url}")
 
     mock_session.configure_mock(
         **{
@@ -167,6 +200,6 @@ def test_download_from_ogd(
     target.mkdir()
     ogd_api.download_from_ogd(req, target)
 
-    assert (target / "some-file.grib").read_bytes() == content
-    assert (target / "horizontal.grib").read_bytes() == content
-    assert (target / "vertical.grib").read_bytes() == content
+    assert (target / "some-file.grib").read_bytes() == content_main
+    assert (target / "horizontal.grib").read_bytes() == content_horizontal
+    assert (target / "vertical.grib").read_bytes() == content_vertical


### PR DESCRIPTION
This PR introduces the following changes:

1. The static horizontal and vertical grid parameter files are now retrieved via the STAC API using pre-signed URLs. Previously, these URLs were hardcoded as a temporary solution due to missing metadata in the STAC catalog. This logic is now integrated into both `get_from_ogd()` and `download_from_ogd()`.
2. The `download_from_ogd()` function has been updated to automatically download the corresponding horizontal and vertical grid parameter files in addition to the requested forecast asset. This is necessary because forecast GRIB files do not include height, latitude, or longitude information, as the data is on an unstructured icosahedral grid.
3. A check was added to avoid re-downloading files that already exist in the target folder, both for the main asset and the static grid files.

https://meteoswiss.atlassian.net/browse/OG-46?atlOrigin=eyJpIjoiZjE0NjA1YWQ0NDNjNDE5NTgyZDVkNzc1NzI0YmRhZGMiLCJwIjoiaiJ9