### PR TITLE
Vertical extrapolation operators

### DIFF
--- a/src/meteodatalab/operators/vertical_extrapolation.py
+++ b/src/meteodatalab/operators/vertical_extrapolation.py
@@ -21,7 +21,11 @@ def extrapolate_temperature_sfc2p(
 ) -> xr.DataArray:
     """Extrapolate temperature to a target pressure level.
 
-    Implements the algorithm described in [1]_.
+    Implements the algorithm described in [1]_. The algorithm extrapolates
+    temperature from the surface to a target pressure level using a
+    polynomial expression of a dimensionless variable y, which is a function of
+    the surface temperature, surface pressure, and geopotential. It assumes
+    a constant lapse rate of 0.0065 K m^-1.
 
     Parameters
     ----------
@@ -56,7 +60,11 @@ def extrapolate_geopotential_sfc2p(
 ) -> xr.DataArray:
     """Extrapolate geopotential to a target pressure level.
 
-    Implements the algorithm described in [1]_.
+    Implements the algorithm described in [1]_. The algorithm extrapolates
+    geopotential from the surface to a target pressure level using a
+    polynomial expression of a dimensionless variable y, which is a function of
+    the surface temperature, surface pressure, and geopotential. It assumes
+    a constant lapse rate of 0.0065 K m^-1.
 
     Parameters
     ----------

--- a/src/meteodatalab/operators/vertical_extrapolation.py
+++ b/src/meteodatalab/operators/vertical_extrapolation.py
@@ -27,6 +27,12 @@ def extrapolate_temperature_sfc2p(
     the surface temperature, surface pressure, and height. It assumes
     a constant lapse rate of 0.0065 K m^-1 and dry air gas constant.
 
+    This extrapolation should be used with caution. Its intended use is to
+    extrapolate temperature to pressure levels below the surface, where
+    values are undefined. This is useful for applications where no missing values
+    are allowed, such as when training data-driven models. Results of the
+    extrapolation are not physically meaningful.
+
     Parameters
     ----------
     t_sfc : xr.DataArray
@@ -65,6 +71,12 @@ def extrapolate_geopotential_sfc2p(
     polynomial expression of a dimensionless variable y, which is a function of
     the surface temperature, surface pressure, and height. It assumes
     a constant lapse rate of 0.0065 K m^-1 and dry air gas constant.
+
+    This extrapolation should be used with caution. Its intended use is to
+    extrapolate geopotential to pressure levels below the surface, where
+    values are undefined. This is useful for applications where no missing values
+    are allowed, such as when training data-driven models. Results of the
+    extrapolation are not physically meaningful.
 
     Parameters
     ----------

--- a/src/meteodatalab/operators/vertical_extrapolation.py
+++ b/src/meteodatalab/operators/vertical_extrapolation.py
@@ -4,7 +4,7 @@
 import numpy as np
 import xarray as xr
 
-# First-party
+# Local
 from .. import metadata
 from .. import physical_constants as pc
 
@@ -28,11 +28,12 @@ def extrapolate_temperature_sfc2p(
     the surface temperature, surface pressure, and height. It assumes
     a constant lapse rate of 0.0065 K m^-1 and dry air gas constant.
 
-    This extrapolation should be used with caution. Its intended use is to
-    extrapolate temperature to pressure levels below the surface, where
-    values are undefined. This is useful for applications where no missing values
-    are allowed, such as when training data-driven models. Results of the
-    extrapolation are not physically meaningful.
+    .. caution :
+        This extrapolation should be used with caution. Its intended use is to
+        extrapolate temperature to pressure levels below the surface, where
+        values are undefined. This is useful for applications where no missing values
+        are allowed, such as when training data-driven models. Results of the
+        extrapolation are not physically meaningful.
 
     Parameters
     ----------
@@ -78,11 +79,12 @@ def extrapolate_geopotential_sfc2p(
     the surface temperature, surface pressure, and height. It assumes
     a constant lapse rate of 0.0065 K m^-1 and dry air gas constant.
 
-    This extrapolation should be used with caution. Its intended use is to
-    extrapolate geopotential to pressure levels below the surface, where
-    values are undefined. This is useful for applications where no missing values
-    are allowed, such as when training data-driven models. Results of the
-    extrapolation are not physically meaningful.
+    .. caution :
+        This extrapolation should be used with caution. Its intended use is to
+        extrapolate geopotential to pressure levels below the surface, where
+        values are undefined. This is useful for applications where no missing values
+        are allowed, such as when training data-driven models. Results of the
+        extrapolation are not physically meaningful.
 
     Parameters
     ----------

--- a/src/meteodatalab/operators/vertical_extrapolation.py
+++ b/src/meteodatalab/operators/vertical_extrapolation.py
@@ -15,7 +15,7 @@ T1 = 298.0
 
 def extrapolate_temperature_sfc2p(
     t_sfc: xr.DataArray,
-    z_sfc: xr.DataArray,
+    h_sfc: xr.DataArray,
     p_sfc: xr.DataArray,
     p_target: float,
 ) -> xr.DataArray:
@@ -24,19 +24,19 @@ def extrapolate_temperature_sfc2p(
     Implements the algorithm described in [1]_. The algorithm extrapolates
     temperature from the surface to a target pressure level using a
     polynomial expression of a dimensionless variable y, which is a function of
-    the surface temperature, surface pressure, and geopotential. It assumes
+    the surface temperature, surface pressure, and height. It assumes
     a constant lapse rate of 0.0065 K m^-1.
 
     Parameters
     ----------
     t_sfc : xr.DataArray
         Surface temperature [K].
-    z_sfc : xr.DataArray
-        Surface geopotential.
+    h_sfc : xr.DataArray
+        Surface height [m].
     p_sfc : xr.DataArray
-        Surface pressure.
+        Surface pressure [Pa].
     p_target : float
-        Target pressure level.
+        Target pressure level [Pa].
 
     Returns
     -------
@@ -48,12 +48,12 @@ def extrapolate_temperature_sfc2p(
     .. [1] https://www.umr-cnrm.fr/gmapdoc/IMG/pdf/ykfpos46t1r1.pdf
 
     """
-    y = _vertical_extrapolation_y_term(t_sfc, p_sfc, z_sfc, p_target)
+    y = _vertical_extrapolation_y_term(t_sfc, p_sfc, h_sfc, p_target)
     return t_sfc * (1 + y + (y**2) / 2 + (y**3) / 6)
 
 
 def extrapolate_geopotential_sfc2p(
-    z_sfc: xr.DataArray,
+    h_sfc: xr.DataArray,
     t_sfc: xr.DataArray,
     p_sfc: xr.DataArray,
     p_target: float,
@@ -63,19 +63,19 @@ def extrapolate_geopotential_sfc2p(
     Implements the algorithm described in [1]_. The algorithm extrapolates
     geopotential from the surface to a target pressure level using a
     polynomial expression of a dimensionless variable y, which is a function of
-    the surface temperature, surface pressure, and geopotential. It assumes
+    the surface temperature, surface pressure, and height. It assumes
     a constant lapse rate of 0.0065 K m^-1.
 
     Parameters
     ----------
-    z_sfc : xr.DataArray
-        Surface geopotential.
+    h_sfc : xr.DataArray
+        Surface height [m].
     t_sfc : xr.DataArray
-        Surface temperature.
+        Surface temperature [K].
     p_sfc : xr.DataArray
-        Surface pressure.
+        Surface pressure [Pa].
     p_target : float
-        Target pressure level.
+        Target pressure level [Pa].
 
     Returns
     -------
@@ -88,27 +88,29 @@ def extrapolate_geopotential_sfc2p(
 
     """
     y = _vertical_extrapolation_y_term(
-        t_sfc, p_sfc, z_sfc, p_target, lapse_rate=LAPSE_RATE
+        t_sfc, p_sfc, h_sfc, p_target, lapse_rate=LAPSE_RATE
     )
-    return z_sfc - pc.r_d * t_sfc * np.log(p_target / p_sfc) * (1 + y / 2 + (y**2) / 6)
+    return h_sfc * pc.g - pc.r_d * t_sfc * np.log(p_target / p_sfc) * (
+        1 + y / 2 + (y**2) / 6
+    )
 
 
-def _vertical_extrapolation_t_zero_prime(t_sfc, z_sfc):
-    t = t_sfc + LAPSE_RATE * z_sfc / pc.g
+def _vertical_extrapolation_t_zero_prime(t_sfc, h_sfc):
+    t = t_sfc + LAPSE_RATE * h_sfc
     t_min = np.minimum(t, T1)
-    return xr.where(z_sfc / pc.g > H2, t_min, t_min * 0.5 + t * 0.5)
+    return xr.where(h_sfc > H2, t_min, t_min * 0.5 + t * 0.5)
 
 
-def _vertical_extrapolation_lapse_rate(z_sfc, t_sfc):
-    t_zero_prime = _vertical_extrapolation_t_zero_prime(t_sfc, z_sfc)
+def _vertical_extrapolation_lapse_rate(h_sfc, t_sfc):
+    t_zero_prime = _vertical_extrapolation_t_zero_prime(t_sfc, h_sfc)
     return xr.where(
-        z_sfc / pc.g < H1,
+        h_sfc < H1,
         LAPSE_RATE,
-        pc.g / z_sfc * np.maximum(t_zero_prime - t_sfc, 0.0),
+        1 / h_sfc * np.maximum(t_zero_prime - t_sfc, 0.0),
     )
 
 
-def _vertical_extrapolation_y_term(t_sfc, p_sfc, z_sfc, p_target, lapse_rate=None):
+def _vertical_extrapolation_y_term(t_sfc, p_sfc, h_sfc, p_target, lapse_rate=None):
     if lapse_rate is None:
-        lapse_rate = _vertical_extrapolation_lapse_rate(z_sfc, t_sfc)
+        lapse_rate = _vertical_extrapolation_lapse_rate(h_sfc, t_sfc)
     return lapse_rate * pc.r_d / pc.g * np.log(p_target / p_sfc)

--- a/src/meteodatalab/operators/vertical_extrapolation.py
+++ b/src/meteodatalab/operators/vertical_extrapolation.py
@@ -1,0 +1,102 @@
+"""Vertical extrapolation operators."""
+
+# Third-party
+import numpy as np
+import xarray as xr
+
+G = 9.80665  # m/s^2
+R_d = 287.053  # Pa K^-1 m^3 kg^-1
+LAPSE_RATE = 0.0065  # K m^-1
+T1 = 2000.0
+T2 = 2500.0
+
+
+def extrapolate_temperature_sfc2p(
+    t_sfc: xr.DataArray,
+    z_sfc: xr.DataArray,
+    p_sfc: xr.DataArray,
+    p_target: float,
+) -> xr.DataArray:
+    """Extrapolate temperature to a target pressure level.
+
+    Implements the algorithm described in [1]_.
+
+    Parameters
+    ----------
+    t_sfc : xr.DataArray
+        Surface temperature.
+    z_sfc : xr.DataArray
+        Surface geopotential.
+    p_sfc : xr.DataArray
+        Surface pressure.
+    p_target : float
+        Target pressure level.
+
+    Returns
+    -------
+    xr.DataArray
+        Extrapolated temperature at the target pressure level.
+
+    References
+    ----------
+    .. [1] https://www.umr-cnrm.fr/gmapdoc/IMG/pdf/ykfpos46t1r1.pdf
+
+    """
+    y = _vertical_extrapolation_y_term(t_sfc, p_sfc, z_sfc, p_target)
+    return t_sfc * (1 + y + (y**2) / 2 + (y**3) / 6)
+
+
+def extrapolate_geopotential_sfc2p(
+    z_sfc: xr.DataArray,
+    t_sfc: xr.DataArray,
+    p_sfc: xr.DataArray,
+    p_target: float,
+) -> xr.DataArray:
+    """Extrapolate geopotential to a target pressure level.
+
+    Implements the algorithm described in [1]_.
+
+    Parameters
+    ----------
+    z_sfc : xr.DataArray
+        Surface geopotential.
+    t_sfc : xr.DataArray
+        Surface temperature.
+    p_sfc : xr.DataArray
+        Surface pressure.
+    p_target : float
+        Target pressure level.
+
+    Returns
+    -------
+    xr.DataArray
+        Extrapolated geopotential at the target pressure level.
+
+    References
+    ----------
+    .. [1] https://www.umr-cnrm.fr/gmapdoc/IMG/pdf/ykfpos46t1r1.pdf
+
+    """
+    y = _vertical_extrapolation_y_term(
+        t_sfc, p_sfc, z_sfc, p_target, lapse_rate=LAPSE_RATE
+    )
+    return z_sfc - R_d * t_sfc * np.log(p_target / p_sfc) * (1 + y / 2 + (y**2) / 6)
+
+
+def _vertical_extrapolation_t_zero_prime(t_sfc, z_sfc):
+    t = t_sfc + LAPSE_RATE * z_sfc / G
+    t_min = np.minimum(t, 298.0)
+    return xr.where(z_sfc / G > T2, t_min, t_min * 0.5 + t * 0.5)
+
+
+def _vertical_extrapolation_lapse_rate(z_sfc, t_sfc):
+    t_zero_prime = _vertical_extrapolation_t_zero_prime(t_sfc, z_sfc)
+    return xr.where(
+        z_sfc / G < T1, LAPSE_RATE, G / z_sfc * np.maximum(t_zero_prime - t_sfc, 0.0)
+    )
+
+
+def _vertical_extrapolation_y_term(t_sfc, p_sfc, z_sfc, p_target, lapse_rate=None):
+    if lapse_rate is None:
+        lapse_rate = _vertical_extrapolation_lapse_rate(z_sfc, t_sfc)
+    return lapse_rate * R_d / G * np.log(p_target / p_sfc)

--- a/src/meteodatalab/operators/vertical_extrapolation.py
+++ b/src/meteodatalab/operators/vertical_extrapolation.py
@@ -24,7 +24,7 @@ def extrapolate_temperature_sfc2p(
     Parameters
     ----------
     t_sfc : xr.DataArray
-        Surface temperature.
+        Surface temperature [K].
     z_sfc : xr.DataArray
         Surface geopotential.
     p_sfc : xr.DataArray

--- a/src/meteodatalab/operators/vertical_extrapolation.py
+++ b/src/meteodatalab/operators/vertical_extrapolation.py
@@ -5,8 +5,8 @@ import numpy as np
 import xarray as xr
 
 # First-party
-from meteodatalab import metadata
-from meteodatalab import physical_constants as pc
+from .. import metadata
+from .. import physical_constants as pc
 
 LAPSE_RATE = 0.0065  # K m^-1
 H1 = 2000.0

--- a/src/meteodatalab/operators/vertical_extrapolation.py
+++ b/src/meteodatalab/operators/vertical_extrapolation.py
@@ -25,7 +25,7 @@ def extrapolate_temperature_sfc2p(
     temperature from the surface to a target pressure level using a
     polynomial expression of a dimensionless variable y, which is a function of
     the surface temperature, surface pressure, and height. It assumes
-    a constant lapse rate of 0.0065 K m^-1.
+    a constant lapse rate of 0.0065 K m^-1 and dry air gas constant.
 
     Parameters
     ----------
@@ -64,7 +64,7 @@ def extrapolate_geopotential_sfc2p(
     geopotential from the surface to a target pressure level using a
     polynomial expression of a dimensionless variable y, which is a function of
     the surface temperature, surface pressure, and height. It assumes
-    a constant lapse rate of 0.0065 K m^-1.
+    a constant lapse rate of 0.0065 K m^-1 and dry air gas constant.
 
     Parameters
     ----------

--- a/tests/test_meteodatalab/test_extpl.py
+++ b/tests/test_meteodatalab/test_extpl.py
@@ -1,0 +1,59 @@
+# Third-party
+from numpy.testing import assert_allclose
+
+# First-party
+import meteodatalab.physical_constants as pc
+from meteodatalab import data_source, grib_decoder
+from meteodatalab.metadata import override, set_origin_xy
+from meteodatalab.operators.destagger import destagger
+from meteodatalab.operators.vertical_extrapolation import (
+    extrapolate_geopotential_sfc2p,
+    extrapolate_temperature_sfc2p,
+)
+from meteodatalab.operators.vertical_interpolation import interpolate_k2p
+
+
+def test_extrapolate_sfc2p(data_dir):
+
+    # define target coordinates
+    target_p = 850.0
+
+    # input data
+    files = [
+        data_dir / "COSMO-1E/1h/ml_sl/000/lfff00000000",
+        data_dir / "COSMO-1E/1h/const/000/lfff00000000c",
+    ]
+
+    # load input data set
+    fds = data_source.FileDataSource(datafiles=files)
+    ds_sfc = grib_decoder.load(fds, {"param": ["HSURF", "T_2M", "PS"]})
+    ds_ml = grib_decoder.load(fds, {"param": ["HHL", "T", "P"]})
+    set_origin_xy(ds_ml, ref_param="HHL")
+    hfl = destagger(ds_ml["HHL"], "z")
+    fi = (hfl * pc.g).assign_attrs(override(hfl.attrs["metadata"], shortName="FI"))
+
+    # call extrapolation operator for geopotential
+    expected = interpolate_k2p(
+        fi, "linear_in_lnp", ds_ml["P"], [target_p], "hPa"
+    ).squeeze("z")
+    res = (
+        extrapolate_geopotential_sfc2p(
+            ds_sfc["HSURF"], ds_sfc["T_2M"], ds_sfc["PS"], target_p * 100.0
+        )
+        .squeeze("z")
+        .where(~expected.isnull())
+    )
+    assert_allclose(res, expected, rtol=0.1)
+
+    # call extrapolation operator for temperature
+    expected = interpolate_k2p(
+        ds_ml["T"], "linear_in_lnp", ds_ml["P"], [target_p], "hPa"
+    ).squeeze("z")
+    res = (
+        extrapolate_temperature_sfc2p(
+            ds_sfc["T_2M"], ds_sfc["HSURF"], ds_sfc["PS"], target_p * 100.0
+        )
+        .squeeze("z")
+        .where(~expected.isnull())
+    )
+    assert_allclose(res, expected, rtol=0.1)


### PR DESCRIPTION
## Purpose

Closes #73 by adding operators to perform vertical extrapolation.

## Code changes:

- added new module `meteodatalab/operators/vertical_extrapolation.py` with the functions needed to perform vertical extrapolation of geopotential and temperature
- added test for the two main extrapolation functions
