### PR TITLE
Add missing number of levels in mars.N_LVL

### DIFF
--- a/src/meteodatalab/mars.py
+++ b/src/meteodatalab/mars.py
@@ -124,6 +124,9 @@ def _load_mapping():
 N_LVL = {
     Model.COSMO_1E: 80,
     Model.COSMO_2E: 60,
+    Model.ICON_CH1_EPS: 80,
+    Model.ICON_CH2_EPS: 80,
+    Model.KENDA_CH1: 80,
 }
 
 


### PR DESCRIPTION
## Purpose

The number of levels for some models were missing, resulting in a `KeyError` when levelist is not specified and we try to get the full list. 
