### PR TITLE
persist sha256 on disk and check

### DIFF
--- a/src/meteodatalab/ogd_api.py
+++ b/src/meteodatalab/ogd_api.py
@@ -8,6 +8,7 @@ import hashlib
 import logging
 import os
 import typing
+from functools import lru_cache
 from pathlib import Path
 from urllib.parse import urlparse
 from uuid import UUID
@@ -148,6 +149,16 @@ def get_asset_url(request: Request):
     return asset_url
 
 
+@lru_cache
+def _get_collection_assets(collection_id: str):
+    url = f"{API_URL}/collections/{collection_id}/assets"
+
+    response = session.get(url)
+    response.raise_for_status()
+
+    return {asset["id"]: asset for asset in response.json().get("assets", [])}
+
+
 def get_collection_asset_url(collection_id: str, asset_id: str) -> str:
     """Get collection asset URL from OGD.
 
@@ -171,12 +182,7 @@ def get_collection_asset_url(collection_id: str, asset_id: str) -> str:
         If the asset is not found in the collection.
 
     """
-    url = f"{API_URL}/collections/{collection_id}/assets"
-
-    response = session.get(url)
-    response.raise_for_status()
-
-    assets = {asset["id"]: asset for asset in response.json().get("assets", [])}
+    assets = _get_collection_assets(collection_id)
     asset_info = assets.get(asset_id)
 
     if not asset_info or "href" not in asset_info:
@@ -263,9 +269,7 @@ def download_from_ogd(request: Request, target: Path) -> None:
     request : Request
         Asset search filters, must select a single asset.
     target : Path
-        Target path where to save the asset.
-        If the path points to an existing directory, the asset will be
-        saved under its own name.
+        Target path where to save the asset, must be a directory.
 
     Raises
     ------
@@ -275,6 +279,12 @@ def download_from_ogd(request: Request, target: Path) -> None:
         if the checksum verification fails.
 
     """
+    if target.exists() and not target.is_dir():
+        raise ValueError(f"target: {target} must be a directory")
+
+    if not target.exists():
+        target.mkdir(parents=True)
+
     # Download main forecast asset
     asset_url = get_asset_url(request)
     _download_with_checksum(asset_url, target)

--- a/tests/test_meteodatalab/test_ogd_api.py
+++ b/tests/test_meteodatalab/test_ogd_api.py
@@ -115,6 +115,10 @@ def test_download_from_ogd(
     content_horizontal = b"horizontal content"
     content_vertical = b"vertical content"
 
+    hash_main = hashlib.sha256(content_main).hexdigest()
+    hash_horizontal = hashlib.sha256(content_horizontal).hexdigest()
+    hash_vertical = hashlib.sha256(content_vertical).hexdigest()
+
     main_href = "https://test.com/path/to/some-file.grib"
     horizontal_href = "https://test.com/path/to/horizontal.grib"
     vertical_href = "https://test.com/path/to/vertical.grib"
@@ -130,13 +134,9 @@ def test_download_from_ogd(
     }
 
     if with_headers:
-        headers_main = {"X-Amz-Meta-Sha256": hashlib.sha256(content_main).hexdigest()}
-        headers_horizontal = {
-            "X-Amz-Meta-Sha256": hashlib.sha256(content_horizontal).hexdigest()
-        }
-        headers_vertical = {
-            "X-Amz-Meta-Sha256": hashlib.sha256(content_vertical).hexdigest()
-        }
+        headers_main = {"X-Amz-Meta-Sha256": hash_main}
+        headers_horizontal = {"X-Amz-Meta-Sha256": hash_horizontal}
+        headers_vertical = {"X-Amz-Meta-Sha256": hash_vertical}
     else:
         headers_main = {}
         headers_horizontal = {}
@@ -202,3 +202,12 @@ def test_download_from_ogd(
     assert (target / "some-file.grib").read_bytes() == content_main
     assert (target / "horizontal.grib").read_bytes() == content_horizontal
     assert (target / "vertical.grib").read_bytes() == content_vertical
+
+    if with_headers:
+        assert (target / "some-file.sha256").read_text() == hash_main
+        assert (target / "horizontal.sha256").read_text() == hash_horizontal
+        assert (target / "vertical.sha256").read_text() == hash_vertical
+    else:
+        assert not (target / "some-file.sha256").exists()
+        assert not (target / "horizontal.sha256").exists()
+        assert not (target / "vertical.sha256").exists()


### PR DESCRIPTION
## Purpose

Persist the file sha256 hash on disk on a file with the same name and the `.sha256` suffix. Lifecycle management of the files is left to the user similarly to the downloaded files. The implementation should now be able to identify partial downloads and replace the affected files but skip downloads for files that comply with the checksum.
