### PR TITLE
Add constant extrapolation operator

### DIFF
--- a/src/meteodatalab/operators/vertical_extrapolation.py
+++ b/src/meteodatalab/operators/vertical_extrapolation.py
@@ -160,10 +160,9 @@ def extrapolate_k2p(
     .. [1] https://www.umr-cnrm.fr/gmapdoc/IMG/pdf/ykfpos46t1r1.pdf
 
     """
-    res = field[{"z": [-1]}]
-    res.attrs = metadata.override(field.metadata, typeOfLevel="isobaricInPa")
-    res = _assign_vcoord(res, p_target)
-    return res
+    return _assign_vcoord(field[{"z": [-1]}], p_target).assign_attrs(
+        metadata.override(field.metadata, typeOfLevel="isobaricInPa")
+    )
 
 
 def _vertical_extrapolation_t_zero_prime(t_sfc, h_sfc):

--- a/src/meteodatalab/operators/vertical_extrapolation.py
+++ b/src/meteodatalab/operators/vertical_extrapolation.py
@@ -1,5 +1,8 @@
 """Vertical extrapolation operators."""
 
+# Standard library
+from typing import Literal
+
 # Third-party
 import numpy as np
 import xarray as xr
@@ -123,13 +126,13 @@ def extrapolate_geopotential_sfc2p(
 def extrapolate_k2p(
     field: xr.DataArray,
     p_target: float,
+    mode: Literal["constant"] = "constant",
 ) -> xr.DataArray:
-    """Extrapolate a field using constant extrapolation.
+    """Extrapolate a field to a target pressure level.
 
-    Implements the algorithm described in [1]_. For all variables except
-    temperature and geopotential (see ``extrapolate_temperature_sfc2p`` and
-    ``extrapolate_geopotential_sfc2p``), the extrapolation is done by simply
-    extending the values of the lowermost model level to the target pressure level.
+    Currently, only the 'constant' extrapolation mode is implemented, where
+    the extrapolation is done by simply extending the values of the
+    lowermost model level to the target pressure level.
 
     .. caution :
         This extrapolation should be used with caution. Its intended use is to
@@ -144,6 +147,8 @@ def extrapolate_k2p(
         Field to extrapolate.
     p_target : float
         Target pressure level [Pa].
+    mode : str, optional
+        Extrapolation mode. Currently only 'constant' is implemented.
 
     Returns
     -------

--- a/tests/test_meteodatalab/test_extpl.py
+++ b/tests/test_meteodatalab/test_extpl.py
@@ -78,3 +78,4 @@ def test_extrapolate_k2p(data_dir):
     res = extrapolate_k2p(ds["QV"], target_p * 100.0).squeeze("z")
 
     assert_allclose(res, expected)
+    assert res.metadata.get("typeOfLevel") == "isobaricInPa"

--- a/tests/test_meteodatalab/test_extpl.py
+++ b/tests/test_meteodatalab/test_extpl.py
@@ -8,6 +8,7 @@ from meteodatalab.metadata import override, set_origin_xy
 from meteodatalab.operators.destagger import destagger
 from meteodatalab.operators.vertical_extrapolation import (
     extrapolate_geopotential_sfc2p,
+    extrapolate_k2p,
     extrapolate_temperature_sfc2p,
 )
 from meteodatalab.operators.vertical_interpolation import interpolate_k2p
@@ -56,3 +57,24 @@ def test_extrapolate_sfc2p(data_dir):
         .where(~expected.isnull())
     )
     assert_allclose(res, expected, rtol=0.04)
+
+
+def test_extrapolate_k2p(data_dir):
+
+    # define target coordinates
+    target_p = 850.0
+
+    # input data
+    files = [
+        str(data_dir / "COSMO-1E/1h/ml_sl/000/lfff00000000"),
+    ]
+
+    # load input data set
+    fds = data_source.FileDataSource(datafiles=files)
+    ds = grib_decoder.load(fds, {"param": ["QV"]})
+
+    # call extrapolation operator
+    expected = ds["QV"][{"z": -1}]
+    res = extrapolate_k2p(ds["QV"], target_p * 100.0).squeeze("z")
+
+    assert_allclose(res, expected)


### PR DESCRIPTION
## Purpose

Add a generic operator to perform constant extrapolation from lowermost model level to a target pressure level. It is meant to be applied for all variables except temperature and geopotential.

## Code changes:

- added the `extrapolate_k2p` operator
- added test 
