### PR TITLE
Add clipping based on lateral boundary strip index

### DIFF
--- a/src/meteodatalab/grib_decoder.py
+++ b/src/meteodatalab/grib_decoder.py
@@ -446,7 +446,7 @@ def save(
     idx = {
         dim: field.coords[key]
         for key in field.dims
-        if (dim := str(key)) not in {"x", "y"}
+        if (dim := str(key)) not in {"x", "y", "cell"}
     }
 
     step_unit = UnitOfTime.MINUTE

--- a/src/meteodatalab/icon_grid.py
+++ b/src/meteodatalab/icon_grid.py
@@ -74,6 +74,10 @@ def load_boundary_idx_from_file(uuid: UUID) -> xr.DataArray:
         / "icon-2/icon_grid_0002_R19B07_mch.nc",
     }
     grid_path = grid_paths.get(uuid)
+    if grid_path is None:
+        raise KeyError(
+            "No grid file for UUID %s. Known UUIDs are %s.", uuid, grid_paths.keys()
+        )
     ds = xr.open_dataset(grid_path)
     return ds["refin_c_ctrl"].assign_attrs(
         uuidOfHGrid=ds.attrs["uuidOfHGrid"],

--- a/src/meteodatalab/icon_grid.py
+++ b/src/meteodatalab/icon_grid.py
@@ -52,6 +52,31 @@ def load_grid_from_file(
     return {"lon": result.clon, "lat": result.clat}
 
 
+def load_boundary_idx_from_file(uuid: UUID) -> xr.DataArray:
+    """Load the lateral boundary strip index from .nc format file.
+
+    Parameters
+    ----------
+    uuid: UUID
+        The UUID of the horizontal grid as specified in the GRIB metadata.
+
+    Returns
+    -------
+    xr.DataArray
+        Lateral boundary strip index for the given grid.
+
+    """
+    grid_dir = Path("/scratch/mch/jenkins/icon/pool/data/ICON/mch/grids/")
+    grid_paths = {
+        UUID("17643da2-5749-59b6-44d2-54a3cd6e2bc0"): grid_dir
+        / "icon-1/icon_grid_0001_R19B08_mch.nc",
+        UUID("bbbd5a09-8554-9924-3c7a-4aa4c8762920"): grid_dir
+        / "icon-2/icon_grid_0002_R19B07_mch.nc",
+    }
+    grid_path = grid_paths.get(uuid)
+    return xr.open_dataset(grid_path)["refin_c_ctrl"]
+
+
 def load_grid_from_balfrin() -> Callable[[UUID], dict[str, xr.DataArray]]:
     """Return a grid source to load grid files when running on balfrin."""
     grid_dir = Path("/scratch/mch/jenkins/icon/pool/data/ICON/mch/grids/")

--- a/src/meteodatalab/icon_grid.py
+++ b/src/meteodatalab/icon_grid.py
@@ -74,7 +74,10 @@ def load_boundary_idx_from_file(uuid: UUID) -> xr.DataArray:
         / "icon-2/icon_grid_0002_R19B07_mch.nc",
     }
     grid_path = grid_paths.get(uuid)
-    return xr.open_dataset(grid_path)["refin_c_ctrl"]
+    ds = xr.open_dataset(grid_path)
+    return ds["refin_c_ctrl"].assign_attrs(
+        uuidOfHGrid=ds.attrs["uuidOfHGrid"],
+    )
 
 
 def load_grid_from_balfrin() -> Callable[[UUID], dict[str, xr.DataArray]]:

--- a/src/meteodatalab/operators/clip.py
+++ b/src/meteodatalab/operators/clip.py
@@ -69,7 +69,7 @@ def clip_lateral_boundary_strip(
 
     if idx is None:
         idx = load_boundary_idx_from_file(original_grid_uuid)
-        if idx.attrs["uuidOfHGrid"] != original_grid_uuid.hex:
+        if idx.attrs["uuidOfHGrid"].replace("-", "") != original_grid_uuid.hex:
             raise ValueError(
                 "The provided grid descriptor file does not match the field's UUID."
             )

--- a/src/meteodatalab/operators/clip.py
+++ b/src/meteodatalab/operators/clip.py
@@ -91,7 +91,7 @@ def clip_lateral_boundary_strip(
         field,
         attrs=metadata.override(
             field.metadata,
-            uuidOfHGrid=str(new_uuid).replace("-", ""),
+            uuidOfHGrid=new_uuid.hex,
             numberOfDataPoints=field.size,
         ),
     )

--- a/src/meteodatalab/operators/clip.py
+++ b/src/meteodatalab/operators/clip.py
@@ -80,7 +80,7 @@ def clip_lateral_boundary_strip(
     new_uuid = uuid5(original_grid_uuid, str(strip_idx))
 
     if new_gridfile is not None:
-        idx = idx.reset_coords()[["clon", "clat"]].sel(cell=~mask)
+        idx = idx.reset_coords()[["clon", "clat"]].sel(cell=~mask)  # type: ignore
         idx.attrs = {"uuidOfHGrid": str(new_uuid)}
         idx.to_netcdf(new_gridfile)
 

--- a/src/meteodatalab/operators/clip.py
+++ b/src/meteodatalab/operators/clip.py
@@ -50,8 +50,6 @@ def clip_lateral_boundary_strip(
         If the field is not on an unstructured grid.
     ValueError
         If the provided grid descriptor file does not match the field's UUID.
-    NotImplementedError
-        If the new grid descriptor file functionality is not implemented yet.
 
     Returns
     -------
@@ -71,7 +69,7 @@ def clip_lateral_boundary_strip(
 
     if idx is None:
         idx = load_boundary_idx_from_file(original_grid_uuid)
-        if idx.attrs["uuidOfHGrid"] != str(original_grid_uuid).replace("-", ""):
+        if idx.attrs["uuidOfHGrid"] != original_grid_uuid.hex:
             raise ValueError(
                 "The provided grid descriptor file does not match the field's UUID."
             )

--- a/src/meteodatalab/operators/clip.py
+++ b/src/meteodatalab/operators/clip.py
@@ -1,0 +1,79 @@
+"""Horizontal clipping operator."""
+
+# Standard library
+from uuid import UUID, uuid4
+
+# Third-party
+import numpy as np
+import xarray as xr
+
+# Local
+from .. import metadata
+from ..icon_grid import load_boundary_idx_from_file
+
+
+def clip_lateral_boundary_strip(
+    field: xr.DataArray,
+    strip_idx: int,
+    idx: xr.DataArray | None = None,
+    new_gridfile: str | None = None,
+) -> xr.DataArray:
+    """Clip the field to the given lateral boundary strip index.
+
+    This function is used to clip a field lateral boundaries using data from the
+    ICON grid descriptor file. Specifically, it uses the indices of the lateral
+    boundary strips (`refin_c_ctrl`) to determine which cells to keep. See the ICON
+    model tutorial for details [1]_. Note that this function only works with regional
+    grids of the ICON model.
+
+    Parameters
+    ----------
+    field: xr.DataArray
+        The field to clip.
+    strip_idx: int
+        The maximum lateral boundary strip index to keep.
+    idx: xr.DataArray, optional
+        The lateral boundary strip index to use.
+    new_gridfile: str, optional
+        The new grid descriptor file to use. This is not implemented yet.
+
+    Raises
+    ------
+    ValueError
+        If the field is not on an unstructured grid.
+    NotImplementedError
+        If the new grid descriptor file functionality is not implemented yet.
+
+    Returns
+    -------
+    xr.DataArray
+        The clipped field.
+
+    References
+    ----------
+    [1] ICON model tutorial 2023:
+        https://www.cosmo-model.org/content/model/documentation/core/iconTutorial_dwd_2023.pdf
+
+    """
+    if not field.metadata.get("gridType") == "unstructured_grid":
+        raise ValueError("Field must be on an unstructured grid.")
+
+    if idx is None:
+        grid_uuid = UUID(field.metadata.get("uuidOfHGrid"))
+        idx = load_boundary_idx_from_file(grid_uuid)
+
+    mask = np.isin(idx.values, np.arange(1, strip_idx + 1))
+
+    # TODO: implement new grid descriptor file functionality
+    if new_gridfile is not None:
+        raise NotImplementedError(
+            "New grid descriptor file functionality is not implemented yet."
+        )
+
+    return xr.DataArray(
+        field.sel(cell=~mask),
+        attrs=metadata.override(
+            field.metadata,
+            uuidOfHGrid=str(uuid4()).replace("-", ""),
+        ),
+    )

--- a/tests/test_meteodatalab/test_clip.py
+++ b/tests/test_meteodatalab/test_clip.py
@@ -9,9 +9,9 @@ from meteodatalab.operators import clip
 
 @pytest.mark.data("iconremap")
 def test_clip_lateral_boundary_strip(data_dir):
-    cdatafile = str(data_dir / "ICON-CH1-EPS_lfff00000000_000")
+    datafile = str(data_dir / "ICON-CH1-EPS_lfff00000000_000")
 
-    reader = data_source.FileDataSource(datafiles=[cdatafile])
+    reader = data_source.FileDataSource(datafiles=[datafile])
     ds = grib_decoder.load(reader, {"param": ["T_2M"]})
     ori = ds["T_2M"]
     ori_uuid = ori.metadata.get("uuidOfHGrid")
@@ -36,9 +36,9 @@ def test_clip_lateral_boundary_strip(data_dir):
 
 @pytest.mark.data("iconremap")
 def test_clip_lateral_boundary_strip_gridfile(data_dir, tmp_path):
-    cdatafile = str(data_dir / "ICON-CH1-EPS_lfff00000000_000")
+    datafile = str(data_dir / "ICON-CH1-EPS_lfff00000000_000")
 
-    reader = data_source.FileDataSource(datafiles=[cdatafile])
+    reader = data_source.FileDataSource(datafiles=[datafile])
     ds = grib_decoder.load(reader, {"param": ["T_2M"]})
     ori = ds["T_2M"]
 

--- a/tests/test_meteodatalab/test_clip.py
+++ b/tests/test_meteodatalab/test_clip.py
@@ -1,0 +1,61 @@
+# Third-party
+import pytest
+import xarray as xr
+
+# First-party
+from meteodatalab import data_source, grib_decoder
+from meteodatalab.operators import clip
+
+
+@pytest.mark.data("iconremap")
+def test_clip_lateral_boundary_strip(data_dir):
+    cdatafile = str(data_dir / "ICON-CH1-EPS_lfff00000000_000")
+
+    reader = data_source.FileDataSource(datafiles=[cdatafile])
+    ds = grib_decoder.load(reader, {"param": ["T_2M"]})
+    ori = ds["T_2M"]
+    ori_uuid = ori.metadata.get("uuidOfHGrid")
+
+    res_14 = clip.clip_lateral_boundary_strip(ori, 14)
+    res_7 = clip.clip_lateral_boundary_strip(ori, 7)
+
+    # check that the size of the clipped data is actually smaller
+    assert res_14.size < res_7.size < ori.size
+
+    # check that the new UUID differs from the original depending on the parameter
+    res_14_uuid = res_14.metadata.get("uuidOfHGrid")
+    res_7_uuid = res_7.metadata.get("uuidOfHGrid")
+    assert res_14_uuid != ori_uuid
+    assert res_7_uuid != ori_uuid
+    assert res_14_uuid != res_7_uuid
+
+    # check that the new UUID is the same for same parameter
+    res_14_clone = clip.clip_lateral_boundary_strip(ori, 14)
+    assert res_14_uuid == res_14_clone.metadata.get("uuidOfHGrid")
+
+
+@pytest.mark.data("iconremap")
+def test_clip_lateral_boundary_strip_gridfile(data_dir, tmp_path):
+    cdatafile = str(data_dir / "ICON-CH1-EPS_lfff00000000_000")
+
+    reader = data_source.FileDataSource(datafiles=[cdatafile])
+    ds = grib_decoder.load(reader, {"param": ["T_2M"]})
+    ori = ds["T_2M"]
+
+    # perform clipping and save the new grid descriptor file
+    res = clip.clip_lateral_boundary_strip(
+        ori, 14, new_gridfile=tmp_path / "_test_gridfile.nc"
+    )
+
+    # save the clipped data to a GRIB file
+    outfile = tmp_path / "_test_clip.grib"
+    with outfile.open("wb") as f:
+        grib_decoder.save(res, f)
+
+    # read the clipped data back, using the new grid descriptor file
+    def _geo_coords_cbk(uuid=None):
+        ds = xr.open_dataset(tmp_path / "_test_gridfile.nc")
+        return {"lat": ds.clat, "lon": ds.clon}
+
+    reader = data_source.FileDataSource(datafiles=[str(outfile)])
+    ds = grib_decoder.load(reader, {"param": ["T_2M"]}, geo_coords=_geo_coords_cbk)

--- a/tests/test_meteodatalab/test_clip.py
+++ b/tests/test_meteodatalab/test_clip.py
@@ -55,6 +55,8 @@ def test_clip_lateral_boundary_strip_gridfile(data_dir, tmp_path):
     # read the clipped data back, using the new grid descriptor file
     def _geo_coords_cbk(uuid=None):
         ds = xr.open_dataset(tmp_path / "_test_gridfile.nc")
+        if str(uuid) != str(ds.attrs["uuidOfHGrid"]):
+            raise ValueError(f"UUID mismatch: {uuid} != {ds.attrs['uuidOfHGrid']}")
         return {"lat": ds.clat, "lon": ds.clon}
 
     reader = data_source.FileDataSource(datafiles=[str(outfile)])


### PR DESCRIPTION
## Purpose

Introduces a new operator to clip points on the lateral boundaries of a regional unstructured grid, using the index of the boundary strip. Closes #85. 

## Code changes:

- add a new `clip_lateral_boundary_strip` operator
- add a function `load_boundary_idx_from_file` to the `icon_grid` module to get the lateral boundary strip index from the grid descriptor file
- add tests
- bugfix in 2eabcec36e9bd598c12463c72fca47a6b342b536
