### PR TITLE
Add lead_time and ref_time validation aliases

### DIFF
--- a/src/meteodatalab/ogd_api.py
+++ b/src/meteodatalab/ogd_api.py
@@ -59,9 +59,15 @@ def _parse_datetime(value: str) -> dt.datetime:
 class Request:
     collection: Collection = dc.field(metadata=dict(exclude=True))
     variable: str
-    reference_datetime: str
+    reference_datetime: str = dc.field(
+        metadata=dict(
+            validation_alias=pydantic.AliasChoices("reference_datetime", "ref_time")
+        )
+    )
     perturbed: bool
-    horizon: dt.timedelta
+    horizon: dt.timedelta = dc.field(
+        metadata=dict(validation_alias=pydantic.AliasChoices("horizon", "lead_time"))
+    )
 
     if typing.TYPE_CHECKING:
         # https://github.com/pydantic/pydantic/issues/10266

--- a/tests/test_meteodatalab/test_ogd_api.py
+++ b/tests/test_meteodatalab/test_ogd_api.py
@@ -84,6 +84,26 @@ def test_reference_datetime(value, valid):
         assert observed.reference_datetime == expected
 
 
+def test_request_alias():
+    req = ogd_api.Request(
+        collection="ogd-forecasting-icon-ch1",
+        variable="T",
+        ref_time="2025-04-08T08:00:00Z",
+        perturbed=False,
+        lead_time="P0DT1H",
+    )
+    observed = req.dump()
+    expected = {
+        "collections": ["ch.meteoschweiz.ogd-forecasting-icon-ch1"],
+        "forecast:variable": "T",
+        "forecast:reference_datetime": "2025-04-08T08:00:00Z",
+        "forecast:perturbed": False,
+        "forecast:horizon": "PT1H",
+    }
+
+    assert observed == expected
+
+
 @mock.patch.object(ogd_api, "session", autospec=True)
 def test_get_from_ogd(mock_session: mock.MagicMock, data_dir: Path):
     datafile = data_dir / "COSMO-1E/1h/ml_sl/000/lfff00000000"


### PR DESCRIPTION
## Purpose

Provide the possibility to use key words that match the name of the relevant dimension in the output data array.

## Code changes:

- Add `ref_time` and `lead_time` as aliases of `reference_datetime` and `horizon` respectively.