### PR TITLE
Add new references to the documentation

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ammaraskar/sphinx-action@7.4.7
       with:
-        pre-build-command: "pip install ."
+        pre-build-command: "pip install .[polytope,regrid]"
         docs-folder: "docs/"
     # Great extra actions to compose with:
     # Create an artifact of the html output.

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -14,9 +14,12 @@ Top level modules
    data_cache
    data_source
    grib_decoder
+   icon_grid
    mars
    mch_model_data
+   metadata
    ogd_api
+   physical_constants
 
 Horizontal operators
 --------------------
@@ -60,5 +63,6 @@ Vertical operators
 .. autosummary::
    :toctree: generated
 
+   operators.vertical_extrapolation
    operators.vertical_interpolation
    operators.vertical_reduction

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -15,6 +15,7 @@ Top level modules
    data_source
    grib_decoder
    mars
+   mch_model_data
    ogd_api
 
 Horizontal operators

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -5,7 +5,7 @@ Using ``ogd_api`` to access ICON-CH1/2-EPS forecasts
 ----------------------------------------------------
 
 The ``ogd_api`` module provides a Python interface to the `STAC search API <https://data.geo.admin.ch/api/stac/static/spec/v1/api.html>`_ on data.geo.admin.ch.
-It enables querying and retrieving numerical weather prediction (NWP) data from **MeteoSwiss**, published through Switzerland’s `Open Government Data (OGD) initiative <https://www.meteoswiss.admin.ch/services-and-publications/service/open-data.html)>`_ and extended for forecast-specific access.
+It enables querying and retrieving numerical weather prediction (NWP) data from **MeteoSwiss**, published through Switzerland’s `Open Government Data (OGD) initiative <https://www.meteoswiss.admin.ch/services-and-publications/service/open-data.html>`_ and extended for forecast-specific access.
 
 You can find interactive Jupyter notebooks demonstrating the usage of ``ogd_api`` here: `MeteoSwiss Open Data NWP Demos <https://github.com/MeteoSwiss/opendata-nwp-demos>`_.
 


### PR DESCRIPTION
## Purpose

- Adding new references or modules to the documentation (refs have to be added manually to appear on the documentation https://meteoswiss.github.io/meteodata-lab/
- Fixing the broken link to the opendata page
- Install the extras (regrid and polytope) in the .github workflows to produce their corresponding section in the documentation
