### PR TITLE
Support multiple lead times

### DIFF
--- a/src/meteodatalab/ogd_api.py
+++ b/src/meteodatalab/ogd_api.py
@@ -158,28 +158,6 @@ def _search(url: str, request: Request):
     return result
 
 
-def _restrict_ref_times(
-    request: Request, ref_times: Iterable[dt.datetime]
-) -> list[dt.datetime]:
-    match request.reference_datetime.split("/"):
-        case [v]:
-            d = _parse_datetime(v)
-            return [ref_time for ref_time in ref_times if ref_time == d]
-        case [v, ".."]:
-            d = _parse_datetime(v)
-            return [ref_time for ref_time in ref_times if ref_time >= d]
-        case ["..", v]:
-            d = _parse_datetime(v)
-            return [ref_time for ref_time in ref_times if ref_time <= d]
-        case [v1, v2]:
-            d1 = _parse_datetime(v1)
-            d2 = _parse_datetime(v2)
-            return [ref_time for ref_time in ref_times if d1 <= ref_time <= d2]
-    raise ValueError(
-        f"Could not parse request.reference_datetime: {request.reference_datetime}"
-    )
-
-
 def get_asset_urls(request: Request) -> list[str]:
     """Get asset URLs from OGD.
 
@@ -239,11 +217,10 @@ def get_asset_urls(request: Request) -> list[str]:
         ref_time = max(complete)
         return [asset_map[(ref_time, lead_time)] for lead_time in lead_times]
 
-    ref_times = _restrict_ref_times(request, set(complete))
     return [
         asset_map[(ref_time, lead_time)]
         for lead_time in lead_times
-        for ref_time in sorted(ref_times)
+        for ref_time in complete
     ]
 
 

--- a/src/meteodatalab/ogd_api.py
+++ b/src/meteodatalab/ogd_api.py
@@ -9,7 +9,6 @@ import logging
 import os
 import re
 import typing
-from collections.abc import Iterable
 from functools import lru_cache
 from pathlib import Path
 from urllib.parse import urlparse

--- a/src/meteodatalab/ogd_api.py
+++ b/src/meteodatalab/ogd_api.py
@@ -30,7 +30,9 @@ session = util.init_session(logger)
 
 
 class Collection(str, enum.Enum):
+    #: Collection of icon-ch1-eps model outputs
     ICON_CH1 = "ogd-forecasting-icon-ch1"
+    #: Collection of icon-ch2-eps model outputs
     ICON_CH2 = "ogd-forecasting-icon-ch2"
 
 

--- a/tests/test_meteodatalab/test_ogd_api.py
+++ b/tests/test_meteodatalab/test_ogd_api.py
@@ -248,7 +248,7 @@ def test_download_from_ogd(
 
 
 @mock.patch.object(ogd_api, "_search")
-def test_get_asset_url_latest(mock_search: mock.MagicMock):
+def test_get_asset_urls_latest(mock_search: mock.MagicMock):
     mock_search.return_value = [
         "https://test.com/icon-ch1-eps-202505100000-1-v_10m-perturb.grib2",
         "https://test.com/icon-ch1-eps-202505120600-1-v_10m-perturb.grib2",
@@ -268,4 +268,30 @@ def test_get_asset_url_latest(mock_search: mock.MagicMock):
 
     assert result == [
         "https://test.com/icon-ch1-eps-202505120600-1-v_10m-perturb.grib2"
+    ]
+
+
+@mock.patch.object(ogd_api, "_search")
+def test_get_asset_urls_multiple_lead_times(mock_search: mock.MagicMock):
+    mock_search.return_value = [
+        "https://test.com/icon-ch1-eps-202505100000-1-v_10m-perturb.grib2",
+        "https://test.com/icon-ch1-eps-202505100000-2-v_10m-perturb.grib2",
+        "https://test.com/icon-ch1-eps-202505100000-3-v_10m-perturb.grib2",
+        "https://test.com/icon-ch1-eps-202505110000-1-v_10m-perturb.grib2",
+    ]
+
+    req = ogd_api.Request(
+        collection="ogd-forecasting-icon-ch1",
+        variable="v_10m",
+        reference_datetime="2025-05-10T00:00:00Z/..",
+        perturbed=True,
+        horizon=["P0DT1H", "P0DT2H", "P0DT3H"],
+    )
+
+    result = ogd_api.get_asset_urls(req)
+
+    assert result == [
+        "https://test.com/icon-ch1-eps-202505100000-1-v_10m-perturb.grib2",
+        "https://test.com/icon-ch1-eps-202505100000-2-v_10m-perturb.grib2",
+        "https://test.com/icon-ch1-eps-202505100000-3-v_10m-perturb.grib2",
     ]

--- a/tests/test_meteodatalab/test_ogd_api.py
+++ b/tests/test_meteodatalab/test_ogd_api.py
@@ -277,6 +277,7 @@ def test_get_asset_urls_multiple_lead_times(mock_search: mock.MagicMock):
         "https://test.com/icon-ch1-eps-202505100000-1-v_10m-perturb.grib2",
         "https://test.com/icon-ch1-eps-202505100000-2-v_10m-perturb.grib2",
         "https://test.com/icon-ch1-eps-202505100000-3-v_10m-perturb.grib2",
+        "https://test.com/icon-ch1-eps-202505100000-4-v_10m-perturb.grib2",
         "https://test.com/icon-ch1-eps-202505110000-1-v_10m-perturb.grib2",
     ]
 

--- a/tests/test_meteodatalab/test_ogd_api.py
+++ b/tests/test_meteodatalab/test_ogd_api.py
@@ -250,10 +250,10 @@ def test_download_from_ogd(
 @mock.patch.object(ogd_api, "_search")
 def test_get_asset_url_latest(mock_search: mock.MagicMock):
     mock_search.return_value = [
-        "https://test.com/icon-ch1-eps-202505100000-0-v_10m-perturb.grib2",
-        "https://test.com/icon-ch1-eps-202505120600-0-v_10m-perturb.grib2",
-        "https://test.com/icon-ch1-eps-202505120000-0-v_10m-perturb.grib2",
-        "https://test.com/icon-ch1-eps-202505110000-0-v_10m-perturb.grib2",
+        "https://test.com/icon-ch1-eps-202505100000-1-v_10m-perturb.grib2",
+        "https://test.com/icon-ch1-eps-202505120600-1-v_10m-perturb.grib2",
+        "https://test.com/icon-ch1-eps-202505120000-1-v_10m-perturb.grib2",
+        "https://test.com/icon-ch1-eps-202505110000-1-v_10m-perturb.grib2",
     ]
 
     req = ogd_api.Request(
@@ -264,6 +264,8 @@ def test_get_asset_url_latest(mock_search: mock.MagicMock):
         horizon="P0DT1H",
     )
 
-    result = ogd_api.get_asset_url(req)
+    result = ogd_api.get_asset_urls(req)
 
-    assert result == "https://test.com/icon-ch1-eps-202505120600-0-v_10m-perturb.grib2"
+    assert result == [
+        "https://test.com/icon-ch1-eps-202505120600-1-v_10m-perturb.grib2"
+    ]


### PR DESCRIPTION
## Purpose

Allow the definition of a list of lead times in the `ogd_api.Request` object. Only forecast reference datetimes that include the all requested lead_times are included. The changes applies to `get_from_ogd` and `download_from_ogd` functions as well.

## Code changes:

- `ogd_api.Request` accepts a list of timedelta or ISO-8601 duration strings in addition to the single value
- `get_asset_url` signature changed to `get_asset_urls` and now returns `list[str]`
