### PR TITLE
fix ogd_api search pagination merge body

### DIFF
--- a/src/meteodatalab/ogd_api.py
+++ b/src/meteodatalab/ogd_api.py
@@ -160,7 +160,9 @@ def _search(url: str, body: dict | None = None):
 
     for link in obj["links"]:
         if link["rel"] == "next":
-            result.extend(_search(link["href"], link["body"]))
+            if link["method"] != "POST" or not link["merge"]:
+                raise RuntimeError(f"Bad link: {link}")
+            result.extend(_search(link["href"], body | link["body"]))
 
     return result
 


### PR DESCRIPTION
## Purpose

Fix the implementation of the pagination in `get_asset_urls` following the STAC specification:
https://github.com/radiantearth/stac-api-spec/blob/release/v1.0.0/item-search/README.md#pagination

## Code changes

- `get_asset_urls` will raise a `RuntimeError` if the next link does not satisfy `method="POST"` and `merge=True`