### PR TITLE
allow empty request on file data source

### DIFF
--- a/src/meteodatalab/data_source.py
+++ b/src/meteodatalab/data_source.py
@@ -134,7 +134,9 @@ class FileDataSource(DataSource):
 
     def _retrieve(self, request: dict):
         req_kwargs = self.request_template | request
-        _ = mars.Request(**req_kwargs)
+        if req_kwargs:
+            # validate only if there is a request
+            _ = mars.Request(**req_kwargs)
         fs = ekd.from_source("file", self.datafiles)
         yield from fs.sel(req_kwargs)
 


### PR DESCRIPTION
## Purpose

Skip request validation if the request is empty. This allows to read entire files without explicitly requesting the parameters that are present in the file.

