### PR TITLE
Replace theta operator with earthkit meteo call

### DIFF
--- a/src/meteodatalab/operators/thetav.py
+++ b/src/meteodatalab/operators/thetav.py
@@ -2,6 +2,7 @@
 
 # Third-party
 import xarray as xr
+from earthkit.meteo import thermo  # type: ignore
 
 # Local
 from .. import metadata
@@ -26,10 +27,10 @@ def fthetav(p: xr.DataArray, t: xr.DataArray, qv: xr.DataArray) -> xr.DataArray:
         virtual potential temperature in K
 
     """
-    # Reference surface pressure for computation of potential temperature
-    p0 = 1.0e5
+    pb, tb, qvb = xr.broadcast(p, t, qv)
 
     return xr.DataArray(
-        data=(p0 / p) ** pc.rdocp * t * (1.0 + (pc.rvd_o * qv / (1.0 - qv))),
+        data=thermo.virtual_potential_temperature(tb.values, pb.values, qvb.values),
+        dims=pb.dims,
         attrs=metadata.override(t.metadata, shortName="THETA_V"),
     )

--- a/tests/test_meteodatalab/test_thetav.py
+++ b/tests/test_meteodatalab/test_thetav.py
@@ -1,9 +1,30 @@
 # Third-party
+from earthkit.meteo import thermo  # type: ignore
 from numpy.testing import assert_allclose
 
 # First-party
 import meteodatalab.operators.thetav as mthetav
 from meteodatalab.grib_decoder import GribReader
+
+
+def calculate_error(p, t, qv):
+    p0 = 1.0e5  # Reference surface pressure
+    r_d = 287.05  # Specific gas constant for dry air [J kg-1 K-1]
+    r_v = 461.51  # Gas constant for water vapour[J kg-1 K-1]
+    cp_d = 1005.0  # Specific heat capacity at constant pressure for dry air [J kg-1 K]
+    rdocp = r_d / cp_d
+    rvd = r_v / r_d
+    rvd_o = rvd - 1.0
+    epsilon = 0.621981
+
+    p_np = p.values
+    t_np = t.values
+    qv_np = qv.values
+
+    c1 = (1.0 - epsilon) / epsilon
+    return (p0 / p_np) ** rdocp * t_np * (1.0 + (rvd_o * qv_np / (1.0 - qv_np))) - (
+        thermo.potential_temperature(t_np, p_np) * (1.0 + c1 * qv_np)
+    )
 
 
 def test_thetav(data_dir, fieldextra):
@@ -23,4 +44,7 @@ def test_thetav(data_dir, fieldextra):
 
     fs_ds = fieldextra("THETAV")
 
-    assert_allclose(fs_ds["THETA_V"], thetav, rtol=1e-6)
+    # due to the difference in constants from earthkit-meteo and fieldextra
+    err = calculate_error(ds["P"], ds["T"], ds["QV"])
+
+    assert_allclose(fs_ds["THETA_V"] - err, thetav, rtol=1e-6)


### PR DESCRIPTION
## Purpose

Using the earthkit-meteo operator functions should benefit performance and help with consistency

## Code changes:

Replace the metodata-lab `thetav` operator with a call to earthkit-meteo `virtual_potential_temperature`

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://meteoswiss.atlassian.net/wiki/spaces/UA/pages/20157433/Factory).
- [ ] Docstrings and type hints are added to new and updated routines, as appropriate
- [ ] All relevant documentation has been updated or added (e.g. README)
- [ ] Unit tests are added or updated for non-operator code
- [ ] New operators are properly tested

Additionally, if the PR updates the version of the package

- [ ] The new version is properly set
- [ ] A Tag will be created after the bump

## Review
For the review process follow the guidelines at [Checklist](https://meteoswiss.atlassian.net/wiki/spaces/UA/pages/20156488/Code+Review)
