### PR TITLE
Implement weight cache

### DIFF
--- a/src/meteodatalab/operators/regrid.py
+++ b/src/meteodatalab/operators/regrid.py
@@ -515,7 +515,14 @@ def _linear_weights_cropped_domain(
     return idx[indices], weights
 
 
-@util.memoize
+def _key_maker(field: xr.DataArray, dst: RegularGrid) -> tuple[str, str] | None:
+    md5 = field.metadata.get("md5Section3", None)
+    if md5 is None:
+        return None
+    return md5, repr(dst)
+
+
+@util.memoize(_key_maker)
 def _compute_barycentric_weights(
     field: xr.DataArray, dst: RegularGrid
 ) -> tuple[NDArray, NDArray]:

--- a/src/meteodatalab/util.py
+++ b/src/meteodatalab/util.py
@@ -67,7 +67,7 @@ class Queue(typing.Generic[K]):
     # Adapted from priority queue example in heapq documentation
 
     class Full(Exception):
-        pass
+        """Exception indicating that the queue is full."""
 
     def __init__(self, maxsize: int) -> None:
         self.queue: list[Entry[K]] = []
@@ -103,6 +103,9 @@ class Queue(typing.Generic[K]):
 
 
 def memoize(key_maker: Callable[P, K], maxsize: int = 10) -> Callable[[F], F]:
+    if maxsize < 1:
+        raise ValueError("maxsize must be 1 or more")
+
     def decorator(func: Callable[P, T]) -> Callable[P, T]:
         cache: dict[K, T] = {}
         queue: Queue[K] = Queue(maxsize=maxsize)

--- a/src/meteodatalab/util.py
+++ b/src/meteodatalab/util.py
@@ -9,11 +9,11 @@ import itertools
 import logging
 import typing
 from collections.abc import Callable
-from typing_extensions import ParamSpec
 
 # Third-party
 import requests
 from requests.adapters import HTTPAdapter
+from typing_extensions import ParamSpec
 from urllib3.util import Retry
 
 

--- a/tests/test_meteodatalab/test_util.py
+++ b/tests/test_meteodatalab/test_util.py
@@ -1,5 +1,7 @@
+# Third-party
 import pytest
 
+# First-party
 from meteodatalab import util
 
 

--- a/tests/test_meteodatalab/test_util.py
+++ b/tests/test_meteodatalab/test_util.py
@@ -1,0 +1,25 @@
+import pytest
+
+from meteodatalab import util
+
+
+def test_queue():
+    queue = util.Queue(maxsize=5)
+    for i in range(5):
+        queue.add_item(i)
+
+    with pytest.raises(queue.Full):
+        queue.add_item(5)
+
+    queue.add_item(3)
+    assert queue.pop_item() == 0
+    queue.add_item(1)
+    assert queue.pop_item() == 2
+    assert queue.pop_item() == 4
+    assert queue.pop_item() == 3
+    assert queue.pop_item() == 1
+    queue.add_item(5)
+    assert queue.pop_item() == 5
+
+    with pytest.raises(KeyError):
+        queue.pop_item()


### PR DESCRIPTION
## Purpose

Implement an in memory cache for the `iconremap` function. The cache keys are based on the field section 3 hash and the repr of the destination grid object. The cache size defaults to 10 instances and the least recently used key is evicted when the cache is full.