### PR TITLE
Add StreamDataSource class

### DIFF
--- a/src/meteodatalab/data_source.py
+++ b/src/meteodatalab/data_source.py
@@ -197,7 +197,7 @@ class StreamDataSource(DataSource):
             field_value = md.get(key, None)
             if md is None:
                 raise KeyError(f"Metadata key '{key}' not found in field metadata.")
-            if isinstance(value, list):
+            if isinstance(value, Container):
                 if field_value not in value:
                     return False
             elif field_value != value:

--- a/src/meteodatalab/data_source.py
+++ b/src/meteodatalab/data_source.py
@@ -196,7 +196,7 @@ class StreamDataSource(DataSource):
         for key, value in request.items():
             field_value = md.get(key, None)
             if md is None:
-                raise ValueError(f"Metadata key '{key}' not found in field metadata.")
+                raise KeyError(f"Metadata key '{key}' not found in field metadata.")
             if isinstance(value, list):
                 if field_value not in value:
                     return False

--- a/src/meteodatalab/data_source.py
+++ b/src/meteodatalab/data_source.py
@@ -5,7 +5,7 @@ import dataclasses as dc
 import os
 import typing
 from abc import ABC, abstractmethod
-from collections.abc import Iterator
+from collections.abc import Container, Iterator
 from contextlib import contextmanager, nullcontext
 from contextvars import ContextVar
 from functools import singledispatchmethod

--- a/src/meteodatalab/data_source.py
+++ b/src/meteodatalab/data_source.py
@@ -174,3 +174,32 @@ class URLDataSource(DataSource):
         req_kwargs = self.request_template | request
         fs = ekd.from_source("url", self.urls)
         yield from fs.sel(**req_kwargs)
+
+
+@dc.dataclass
+class StreamDataSource(DataSource):
+    stream: list[str] | None = None
+
+    def _retrieve(self, request: dict):
+        req_kwargs = self.request_template | request
+        fs = ekd.from_source("stream", self.stream)
+        if req_kwargs:
+            _ = mars.Request(**req_kwargs)
+            yield from (field for field in fs if self._match_request(field, req_kwargs))
+        else:
+            yield from fs
+
+    @staticmethod
+    def _match_request(field, request: dict) -> bool:
+        """Check if the field matches the request."""
+        md = field.metadata()
+        for key, value in request.items():
+            field_value = md.get(key, None)
+            if md is None:
+                raise ValueError(f"Metadata key '{key}' not found in field metadata.")
+            if isinstance(value, list):
+                if field_value not in value:
+                    return False
+            elif field_value != value:
+                return False
+        return True

--- a/src/meteodatalab/data_source.py
+++ b/src/meteodatalab/data_source.py
@@ -178,7 +178,7 @@ class URLDataSource(DataSource):
 
 @dc.dataclass
 class StreamDataSource(DataSource):
-    stream: list[str] | None = None
+    stream: typing.BinaryIO | None = None
 
     def _retrieve(self, request: dict):
         req_kwargs = self.request_template | request
@@ -190,7 +190,7 @@ class StreamDataSource(DataSource):
             yield from fs
 
     @staticmethod
-    def _match_request(field, request: dict) -> bool:
+    def _match_request(field: ekd.Field, request: dict) -> bool:
         """Check if the field matches the request."""
         md = field.metadata()
         for key, value in request.items():

--- a/tests/test_meteodatalab/test_data_source.py
+++ b/tests/test_meteodatalab/test_data_source.py
@@ -128,23 +128,6 @@ def test_retrieve_url(server):
         assert field.metadata("shortName") == "T"
 
 
-# TODO: which one to use?
-def test_retrieve_stream_mock(mock_from_source, mock_grib_def_ctx):
-    streamfile = "foo"
-    param = "bar"
-
-    with open(streamfile, "w") as f:
-        source = data_source.StreamDataSource(stream=f)
-        for _ in source.retrieve(param):
-            pass
-
-    assert mock_grib_def_ctx.mock_calls == [call("cosmo")]
-    assert mock_from_source.mock_calls == [
-        call("stream", f),
-        call().__iter__(),
-    ]
-
-
 def test_retrieve_stream(data_dir):
     datafile = data_dir / "COSMO-1E/1h/ml_sl/000/lfff00000000"
     request = {"param": "T", "levelist": 10}

--- a/tests/test_meteodatalab/test_data_source.py
+++ b/tests/test_meteodatalab/test_data_source.py
@@ -126,3 +126,31 @@ def test_retrieve_url(server):
     source = data_source.URLDataSource(urls=urls)
     for field in source.retrieve({"param": "T"}):
         assert field.metadata("shortName") == "T"
+
+
+# TODO: which one to use?
+def test_retrieve_stream_mock(mock_from_source, mock_grib_def_ctx):
+    streamfile = "foo"
+    param = "bar"
+
+    with open(streamfile, "w") as f:
+        source = data_source.StreamDataSource(stream=f)
+        for _ in source.retrieve(param):
+            pass
+
+    assert mock_grib_def_ctx.mock_calls == [call("cosmo")]
+    assert mock_from_source.mock_calls == [
+        call("stream", f),
+        call().__iter__(),
+    ]
+
+
+def test_retrieve_stream(data_dir):
+    datafile = data_dir / "COSMO-1E/1h/ml_sl/000/lfff00000000"
+    request = {"param": "T", "levelist": 10}
+
+    with open(datafile, "rb") as f:
+        source = data_source.StreamDataSource(stream=f)
+        for field in source.retrieve(request):
+            assert field.metadata("shortName") == "T"
+            assert field.metadata("levelist") == 10


### PR DESCRIPTION
## Purpose

This PR introduces the `StreamDataSource` class, which can be used to read data from a stream of bytes. This can be useful when the GRIB data can only be accessed in-memory, for instance while extracting from a tar archive in a python program. 


## Code changes:

- Added new class `StreamDataSource`
- Added test