### PR TITLE
[Fix] collection name doesn't contain `-eps`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,10 @@
 # History
 
+## [0.7.1] (2026-05-13)
+
+### Fix
+- ICON-CH1/2-EPS are fetched from the appropriate collection asset.
+
 ## [0.7.0] (2026-05-11)
 
 ### Fix
@@ -214,6 +219,7 @@ To be removed in version 0.6
 - Added ninjo_k2th product
 - Added GRIB data loader based on earthkit-data
 
+[0.7.1]: https://github.com/MeteoSwiss/meteodata-lab/compare/v0.7.0..v0.7.1
 [0.7.0]: https://github.com/MeteoSwiss/meteodata-lab/compare/v0.7.0-rc2..v0.7.0
 [0.7.0-rc2]: https://github.com/MeteoSwiss/meteodata-lab/compare/v0.7.0-rc1..v0.7.0-rc2
 [0.7.0-rc1]: https://github.com/MeteoSwiss/meteodata-lab/compare/v0.6.0..v0.7.0-rc1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "meteodata-lab"
-version = "0.7.0"
+version = "0.7.1"
 description = "A data post-processing framework on the basis of xarray."
 readme = "README.md"
 keywords = ["Icon", "Data Processing"]

--- a/src/meteodatalab/ogd_api.py
+++ b/src/meteodatalab/ogd_api.py
@@ -305,16 +305,12 @@ def _get_geo_coord_url(uuid: UUID, collection: Collection) -> str:
     if model_name is None:
         logger.warning("Grid UUID not found")
 
-    mapping = {
-        Collection.ICON_CH1: "forecasting-icon-ch1-eps",
-        Collection.ICON_CH2: "forecasting-icon-ch2-eps",
-        Collection.KENDA_CH1: "analysis-kenda-ch1",
-    }
+    # Collection name doesn't include "eps"
+    # while asset names keep the eps model suffix.
+    collection_id = f"ch.meteoschweiz.{collection}"
+    model_suffix = _collection_constants_model_suffix(collection)
 
-    collection_name = mapping[collection]
-    asset_name = _collection_constants_model_suffix(collection).removesuffix("-eps")
-    collection_id = f"ch.meteoschweiz.ogd-{collection_name}"
-    asset_id = f"horizontal_constants_{asset_name}.grib2"
+    asset_id = f"horizontal_constants_{model_suffix}.grib2"
 
     return get_collection_asset_url(collection_id, asset_id)
 

--- a/src/meteodatalab/ogd_api.py
+++ b/src/meteodatalab/ogd_api.py
@@ -53,9 +53,8 @@ def _parse_datetime(value: str) -> dt.datetime:
     return dt.datetime.strptime(value, "%Y-%m-%dT%H:%M:%S%z")
 
 
-def _collection_constants_model_suffix(collection: Collection | str) -> str:
+def _collection_constants_model_suffix(collection: Collection) -> str:
     """Return the model suffix used in static constants asset IDs."""
-    collection_value = str(collection)
 
     mapping = {
         Collection.ICON_CH1.value: "icon-ch1-eps",
@@ -64,11 +63,11 @@ def _collection_constants_model_suffix(collection: Collection | str) -> str:
     }
 
     try:
-        return mapping[collection_value]
+        return mapping[collection.value]
     except KeyError as exc:
         raise KeyError(
             "No constants model suffix mapping defined "
-            f"for collection {collection_value!r}."
+            f"for collection {collection.value!r}."
         ) from exc
 
 
@@ -305,9 +304,10 @@ def _get_geo_coord_url(uuid: UUID, collection: Collection) -> str:
     if model_name is None:
         logger.warning("Grid UUID not found")
 
+    collection_id = f"ch.meteoschweiz.{collection.value}"
+
     # Collection name doesn't include "eps"
     # while asset names keep the eps model suffix.
-    collection_id = f"ch.meteoschweiz.{collection}"
     model_suffix = _collection_constants_model_suffix(collection)
 
     asset_id = f"horizontal_constants_{model_suffix}.grib2"
@@ -359,7 +359,7 @@ def get_from_ogd(request: Request) -> xr.DataArray:
     return grib_decoder.load(
         source,
         {"param": request.variable},
-        geo_coords=partial(_geo_coords, collection=request.collection),
+        geo_coords=partial(_geo_coords, collection=Collection(request.collection)),
     )[request.variable]
 
 
@@ -400,7 +400,7 @@ def download_from_ogd(request: Request, target: Path) -> None:
         _download_with_checksum(asset_url, target)
 
     collection_id = f"ch.meteoschweiz.{request.collection}"
-    model_suffix = _collection_constants_model_suffix(request.collection)
+    model_suffix = _collection_constants_model_suffix(Collection(request.collection))
 
     # Download coordinate files
     for prefix in ["horizontal", "vertical"]:

--- a/src/meteodatalab/ogd_api.py
+++ b/src/meteodatalab/ogd_api.py
@@ -55,7 +55,6 @@ def _parse_datetime(value: str) -> dt.datetime:
 
 def _collection_constants_model_suffix(collection: Collection) -> str:
     """Return the model suffix used in static constants asset IDs."""
-
     mapping = {
         Collection.ICON_CH1.value: "icon-ch1-eps",
         Collection.ICON_CH2.value: "icon-ch2-eps",

--- a/src/meteodatalab/operators/wind.py
+++ b/src/meteodatalab/operators/wind.py
@@ -42,6 +42,7 @@ def speed(u: xr.DataArray, v: xr.DataArray) -> xr.DataArray:
     name = {"U": "SP", "U_10M": "SP_10M"}[u.parameter["shortName"]]
     return xr.DataArray(
         wind.speed(u.values, v.values),
+        dims=u.dims,
         attrs=override(u.metadata, shortName=name),
     )
 
@@ -84,7 +85,7 @@ def direction(u: xr.DataArray, v: xr.DataArray) -> xr.DataArray:
         u_g = u
         v_g = v
     else:
-        ValueError(f"Differing or unknown vector references ({u.vref=}, {v.vref=})")
+        raise ValueError(f"Differing or unknown vector references ({u.vref=}, {v.vref=})")
     name = {"U": "DD", "U_10M": "DD_10M"}[u.parameter["shortName"]]
     return xr.DataArray(
         rad2deg * np.arctan2(u_g, v_g) + 180,

--- a/src/meteodatalab/operators/wind.py
+++ b/src/meteodatalab/operators/wind.py
@@ -85,7 +85,9 @@ def direction(u: xr.DataArray, v: xr.DataArray) -> xr.DataArray:
         u_g = u
         v_g = v
     else:
-        raise ValueError(f"Differing or unknown vector references ({u.vref=}, {v.vref=})")
+        raise ValueError(
+            f"Differing or unknown vector references ({u.vref=}, {v.vref=})"
+        )
     name = {"U": "DD", "U_10M": "DD_10M"}[u.parameter["shortName"]]
     return xr.DataArray(
         rad2deg * np.arctan2(u_g, v_g) + 180,

--- a/tests/test_meteodatalab/test_ogd_api.py
+++ b/tests/test_meteodatalab/test_ogd_api.py
@@ -2,7 +2,6 @@
 import datetime as dt
 import hashlib
 import typing
-import uuid
 from contextlib import nullcontext
 from pathlib import Path
 from unittest import mock

--- a/tests/test_meteodatalab/test_ogd_api.py
+++ b/tests/test_meteodatalab/test_ogd_api.py
@@ -5,6 +5,7 @@ import typing
 from contextlib import nullcontext
 from pathlib import Path
 from unittest import mock
+from uuid import UUID
 
 # Third-party
 import pydantic
@@ -302,7 +303,7 @@ model_to_uuid = {v: k for k, v in icon_grid.GRID_UUID_TO_MODEL.items()}
 
 
 @pytest.mark.parametrize(
-    "uuid,collection,expected_coll,expected_file",
+    "uuid,collection,exp_collection_id,exp_asset_id",
     [
         (
             model_to_uuid["icon-ch1-eps"],
@@ -326,11 +327,15 @@ model_to_uuid = {v: k for k, v in icon_grid.GRID_UUID_TO_MODEL.items()}
 )
 @mock.patch.object(ogd_api, "get_collection_asset_url")
 def test_get_geo_coord_url(
-    mock_get: mock.MagicMock, uuid, collection, expected_coll, expected_file
+    mock_get: mock.MagicMock,
+    uuid: UUID,
+    collection: ogd_api.Collection,
+    exp_collection_id: str,
+    exp_asset_id: str,
 ):
 
     mock_get.return_value = "some_url"
 
     assert "some_url" == ogd_api._get_geo_coord_url(uuid, collection)
 
-    assert mock_get.mock_calls == [mock.call(expected_coll, expected_file)]
+    assert mock_get.mock_calls == [mock.call(exp_collection_id, exp_asset_id)]

--- a/tests/test_meteodatalab/test_ogd_api.py
+++ b/tests/test_meteodatalab/test_ogd_api.py
@@ -2,6 +2,7 @@
 import datetime as dt
 import hashlib
 import typing
+import uuid
 from contextlib import nullcontext
 from pathlib import Path
 from unittest import mock
@@ -13,7 +14,7 @@ import requests
 import xarray as xr
 
 # First-party
-from meteodatalab import ogd_api
+from meteodatalab import icon_grid, ogd_api
 
 
 def test_request_dump():
@@ -296,3 +297,41 @@ def test_get_asset_urls_multiple_lead_times(mock_search: mock.MagicMock):
         "https://test.com/icon-ch1-eps-202505100000-2-v_10m-perturb.grib2",
         "https://test.com/icon-ch1-eps-202505100000-3-v_10m-perturb.grib2",
     ]
+
+
+model_to_uuid = {v: k for k, v in icon_grid.GRID_UUID_TO_MODEL.items()}
+
+
+@pytest.mark.parametrize(
+    "uuid,collection,expected_coll,expected_file",
+    [
+        (
+            model_to_uuid["icon-ch1-eps"],
+            ogd_api.Collection.ICON_CH1,
+            "ch.meteoschweiz.ogd-forecasting-icon-ch1",
+            "horizontal_constants_icon-ch1-eps.grib2",
+        ),
+        (
+            model_to_uuid["icon-ch2-eps"],
+            ogd_api.Collection.ICON_CH2,
+            "ch.meteoschweiz.ogd-forecasting-icon-ch2",
+            "horizontal_constants_icon-ch2-eps.grib2",
+        ),
+        (
+            model_to_uuid["icon-ch1-eps"],
+            ogd_api.Collection.KENDA_CH1,
+            "ch.meteoschweiz.ogd-analysis-kenda-ch1",
+            "horizontal_constants_kenda-ch1.grib2",
+        ),
+    ],
+)
+@mock.patch.object(ogd_api, "get_collection_asset_url")
+def test_get_geo_coord_url(
+    mock_get: mock.MagicMock, uuid, collection, expected_coll, expected_file
+):
+
+    mock_get.return_value = "some_url"
+
+    assert "some_url" == ogd_api._get_geo_coord_url(uuid, collection)
+
+    assert mock_get.mock_calls == [mock.call(expected_coll, expected_file)]


### PR DESCRIPTION
## Purpose

- Fix for wrong collection name for icon-ch1-eps and icon-ch2-eps. See [comment](https://github.com/MeteoSwiss/meteodata-lab/commit/a7a8c7962fb599d640a9ac0290a50ea7248529bb#r185138024) below.
- Updating meteodata-lab raised another issue in the wind speed notebook. Since we used the operator of earthkit-meteo the dims were not pushed in the outputs and selecting on the `eps` dim raised an error. Hence, adding the dims in the outputs of the wind_speed operator. 
 

> In my environment with meteodata-lab 0.7.0 this makes a request to https://data.geo.admin.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-forecasting-icon-ch2-eps/assets which results in a 404 error:
> 
> [ERROR] HTTPError: 404 Client Error: Not Found for url: https://data.geo.admin.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-forecasting-icon-ch2-eps/assets
> Traceback (most recent call last):
>   File "/var/task/ingestion/handler.py", line 34, in lambda_handler
>     dict_weather = fetch_variables_mch_ogd(
>   File "/var/task/ingestion/retrieval.py", line 30, in fetch_variables_mch_ogd
>     return {
>   File "/var/task/ingestion/retrieval.py", line 31, in <dictcomp>
>     variable: ogd_api.get_from_ogd(
>   File "/usr/local/lib/python3.11/site-packages/meteodatalab/ogd_api.py", line 363, in get_from_ogd
>     return grib_decoder.load(
>   File "/usr/local/lib/python3.11/site-packages/meteodatalab/grib_decoder.py", line 296, in load
>     buffer_map = _load_buffer_map(source, request, geo_coords=geo_coords)
>   File "/usr/local/lib/python3.11/site-packages/meteodatalab/grib_decoder.py", line 221, in _load_buffer_map
>     buffer.load(field, geo_coords=geo_coords)
>   File "/usr/local/lib/python3.11/site-packages/meteodatalab/grib_decoder.py", line 161, in load
>     self.hcoords, self.hdims = _get_hcoords(field, geo_coords=geo_coords)
>   File "/usr/local/lib/python3.11/site-packages/meteodatalab/grib_decoder.py", line 99, in _get_hcoords
>     return geo_coords(grid_uuid), hdims
>   File "/usr/local/lib/python3.11/site-packages/meteodatalab/ogd_api.py", line 327, in _geo_coords
>     url = _get_geo_coord_url(uuid, collection)
>   File "/usr/local/lib/python3.11/site-packages/meteodatalab/ogd_api.py", line 319, in _get_geo_coord_url
>     return get_collection_asset_url(collection_id, asset_id)
>   File "/usr/local/lib/python3.11/site-packages/meteodatalab/ogd_api.py", line 290, in get_collection_asset_url
>     assets = _get_collection_assets(collection_id)
>   File "/usr/local/lib/python3.11/site-packages/meteodatalab/ogd_api.py", line 262, in _get_collection_assets
>     response.raise_for_status()
>   File "/usr/local/lib/python3.11/site-packages/requests/models.py", line 1167, in raise_for_status
>     raise HTTPError(http_error_msg, response=self)
>
> With meteodata-lab 0.6.0 the working url is: https://data.geo.admin.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-forecasting-icon-ch2/assets
